### PR TITLE
check the number based on webpage

### DIFF
--- a/tests/testthat/test-organization_list.R
+++ b/tests/testthat/test-organization_list.R
@@ -1,12 +1,20 @@
 context("organization_list")
 
+organization_num <- local({
+  res <- httr::GET("http://demo.ckan.org/organization")
+  httr::stop_for_status(res)
+  html <- httr::content(res, as = "text")
+  tmp <- regmatches(html, regexec("(\\d+) organizations found", html))
+  as.integer(tmp[[1]][2])
+})
+
 test_that("organization_list gives back expected class types", {
   a <- organization_list(url = "http://demo.ckan.org")
 
   expect_is(a, "list")
   expect_is(a[[1]], "list")
   expect_is(a[[1]]$state, "character")
-  expect_equal(length(a), 375)
+  expect_equal(length(a), organization_num)
 })
 
 test_that("organization_list works giving back json output", {
@@ -15,6 +23,6 @@ test_that("organization_list works giving back json output", {
   expect_is(b, "character")
   expect_is(b_df, "list")
   expect_is(b_df$result, "data.frame")
-  expect_equal(nrow(b_df$result), 375)
+  expect_equal(nrow(b_df$result), organization_num)
 })
 

--- a/tests/testthat/test-organization_show.R
+++ b/tests/testthat/test-organization_show.R
@@ -1,16 +1,29 @@
 context("organization_show")
 
+target <- "znew-organization-xyz"
+dataset_num <- local({
+  res <- httr::GET(paste0("http://demo.ckan.org/organization/", target))
+  httr::stop_for_status(res)
+  html <- httr::content(res, as = "text")
+  tmp <- regmatches(html, regexec("(\\d+) datasets? found", html))
+  as.integer(tmp[[1]][2])
+})
+
 test_that("organization_show gives back expected class types", {
-  a <- organization_show('03f23a29-906c-45ad-8f77-845a219aa111', url = "http://demo.ckan.org")
+  a <- organization_show('znew-organization-xyz', url = "http://demo.ckan.org")
 
   expect_is(a, "list")
   expect_is(a[[1]], "list")
   expect_is(a[[1]][[1]]$name, "character")
   expect_equal(length(a), 19L)
+
+  a <- organization_show('znew-organization-xyz', url = "http://demo.ckan.org", include_datasets = TRUE)
+  expect_equal(a$package_count, dataset_num)
+  expect_equal(length(a$packages), dataset_num)
 })
 
 test_that("organization_show works giving back json output", {
-  b <- organization_show('03f23a29-906c-45ad-8f77-845a219aa111', url = "http://demo.ckan.org", as = 'json')
+  b <- organization_show('znew-organization-xyz', url = "http://demo.ckan.org", as = 'json')
   b_df <- jsonlite::fromJSON(b)
   expect_is(b, "character")
   expect_is(b_df, "list")


### PR DESCRIPTION
The data in the "http://demo.cakn.org" is growing, so we need to match the number from the web page and the API from ckanr.