### PR TITLE
add XML to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,4 +16,5 @@ Imports:
     jsonlite
 Suggests:
     roxygen2,
-    testthat
+    testthat,
+    XML


### PR DESCRIPTION
The httr::content will try XML to parse the html formatted response. Therefore, I suggest to put the XML into Suggests. We could parse the response and compare with our API in the unit test.