### PR TITLE
Using Sys.env to store test server settings

### DIFF
--- a/R/ckanr_options.R
+++ b/R/ckanr_options.R
@@ -1,7 +1,8 @@
 #' Get ckanr options
 #'
 #' @export
-#' @return Prints your base url, and API key (if used)
+#' @return Prints your base url, API key (if used), and optional test server
+#'  settings (URL, API key, a dataset ID and a resource ID)
 #' @seealso \code{\link{set_ckanr_url}}, \code{\link{get_ckanr_url}},
 #' \code{\link{set_api_key}}
 #' @family ckanr options
@@ -12,6 +13,7 @@ ckanr_options <- function() {
               key = getOption("X-CKAN-API-Key", NULL),
               ckanr.test.url = getOption("ckanr.test.url", NULL),
               ckanr.test.key = getOption("ckanr.test.key", NULL),
+              ckanr.test.did = getOption("ckanr.test.did", NULL),
               ckanr.test.rid = getOption("ckanr.test.rid", NULL)
   )
   structure(ops, class = "ckanr_options")
@@ -23,6 +25,7 @@ print.ckanr_options <- function(x) {
   cat("API key: ", x$key, "\n")
   cat("Test CKAN URL:", x$ckanr.test.url, "\n")
   cat("Test CKAN API key:", x$ckanr.test.key, "\n")
+  cat("Test CKAN dataset ID:", x$ckanr.test.did, "\n")
   cat("Test CKAN resource ID:", x$ckanr.test.rid)
 }
 
@@ -31,6 +34,9 @@ print.ckanr_options <- function(x) {
 #'
 #'  Tests require a valid CKAN URL, a privileged API key for that URL,
 #'  plus the IDs of an existing dataset and an existing resource, repectively.
+#'
+#'  The settings are written to both options and Sys.env. Testthat can only
+#'  access Sys.env.
 #'
 #'  @param url A valid CKAN URL for testing purposes
 #'  @param key A valid CKAN API key privileged to create datasets at URL
@@ -42,20 +48,37 @@ set_test_env <- function(url, key, did, rid) {
   options(ckanr.test.key = key)
   options(ckanr.test.did = did)
   options(ckanr.test.rid = rid)
+  Sys.setenv("ckanr.test.url" = url)
+  Sys.setenv("ckanr.test.key" = key)
+  Sys.setenv("ckanr.test.did" = did)
+  Sys.setenv("ckanr.test.rid" = rid)
 }
 
 #' Get the CKAN test URL
 #' @export
-get_test_url <- function(){getOption("ckan.test.url", NULL)}
+get_test_url <- function(){
+  #getOption("ckanr.test.url")
+  #ckanr_options()$ckanr.test.url
+  Sys.getenv("ckanr.test.url")
+}
 
 #' Get the CKAN test key
 #' @export
-get_test_key <- function(){getOption("ckan.test.key", NULL)}
+get_test_key <- function(){
+  #getOption("ckanr.test.key")
+  Sys.getenv("ckanr.test.key")
+}
 
 #' Get the CKAN test dataset ID
 #' @export
-get_test_did <- function(){getOption("ckan.test.did", NULL)}
+get_test_did <- function(){
+  #getOption("ckanr.test.did")
+  Sys.getenv("ckanr.test.did")
+}
 
 #' Get the CKAN resource ID
 #' @export
-get_test_rid <- function(){getOption("ckan.test.rid", NULL)}
+get_test_rid <- function(){
+  #getOption("ckanr.test.rid")
+  Sys.getenv("ckanr.test.rid")
+}

--- a/R/ds_create_dataset.R
+++ b/R/ds_create_dataset.R
@@ -1,7 +1,7 @@
 #' Datastore - create a dataset
 #'
 #' @export
-#' @importFrom httr upload_file add_headers
+#' @importFrom httr upload_file add_headers POST
 #'
 #' @param package_id (character) Existing package ID to add a resource to (required)
 #' @param name (character) Name of the new resource (required)

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -42,13 +42,12 @@ resource_update <- function(id, path,
                             url=get_ckanr_url(),
                             key=getOption("X-CKAN-API-Key", NULL),
                             as = 'list', ...) {
-  require(httr)
   path <- path.expand(path)
   body <- list(id = id,
                url = 'upload',
-               upload = httr::upload_file(path),
+               upload = upload_file(path),
                last_modified=Sys.time())
-  res <- httr::POST(file.path(url, ck(), 'resource_update'),
+  res <- POST(file.path(url, ck(), 'resource_update'),
                     add_headers(Authorization = key),
                     body = body,
                     ...)

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -40,7 +40,7 @@
 #' }
 resource_update <- function(id, path,
                             url=get_ckanr_url(),
-                            key=getOption("X-CKAN-API-Key", NULL),
+                            key=getOption("X-CKAN-API-Key"),
                             as = 'list', ...) {
   path <- path.expand(path)
   body <- list(id = id,
@@ -48,9 +48,8 @@ resource_update <- function(id, path,
                upload = upload_file(path),
                last_modified=Sys.time())
   res <- POST(file.path(url, ck(), 'resource_update'),
-                    add_headers(Authorization = key),
-                    body = body,
-                    ...)
+              add_headers(Authorization = key),
+              body = body, ...)
   stop_for_status(res)
   res <- content(res, "text")
   switch(as, json = res, list = jsl(res), table = jsd(res))

--- a/man/ckanr_options.Rd
+++ b/man/ckanr_options.Rd
@@ -7,7 +7,8 @@
 ckanr_options()
 }
 \value{
-Prints your base url, and API key (if used)
+Prints your base url, API key (if used), and optional test server
+ settings (URL, API key, a dataset ID and a resource ID)
 }
 \description{
 Get ckanr options

--- a/man/set_test_env.Rd
+++ b/man/set_test_env.Rd
@@ -19,4 +19,8 @@ set_test_env(url, key, did, rid)
 Tests require a valid CKAN URL, a privileged API key for that URL,
  plus the IDs of an existing dataset and an existing resource, repectively.
 }
+\details{
+The settings are written to both options and Sys.env. Testthat can only
+ access Sys.env.
+}
 

--- a/tests/testthat/test-ds_create_dataset.R
+++ b/tests/testthat/test-ds_create_dataset.R
@@ -9,29 +9,28 @@ key = get_test_key()
 did = get_test_did()
 
 # Dataset fields
-ds_title <- "ckanR test"
-ds_description <- "A test dataset, updated from ckanR's test suite."
-
+ds_title <- "ckanR test resource"
 
 # Test CKAN environment
 test_that("The CKAN URL is set", { expect_is(url, "character") })
 test_that("The CKAN API key is set", { expect_is(key, "character") })
 test_that("The CKAN Dataset ID is set", { expect_is(did, "character") })
 
+# Helper functions to test CKAN environment
 check_ckan <- function(){
   if(!ping(url)) {
-    skip(paste0("CKAN is offline. Tests for ds_create_dataset require a live ",
-                "CKAN URL, consult ?set_test_env"))
+    skip(paste("CKAN is offline.",
+               "Did you set CKAN test settings with ?set_test_env ?",
+               "Does the test CKAN server run at", url, "?"))
   }
-  p <- package_show(did, url=url)
-
 }
+
 check_dataset <- function(){
   p <- package_show(did, url=url)
-  if(class(res)!="list"){
-    skip(paste0("The CKAN test dataset doesn't seem to exist. Tests for ",
-                "ds_dataset_create require an existing CKAN dataset ID. ",
-                "consult ?set_test_env"))
+  if(class(p)!="list" && p$id!=did){
+    skip(paste("The CKAN test dataset wasn't found.",
+               "Did you set CKAN test settings with ?set_test_env ?",
+               "Does a dataset with ID", did, "exist on", url, "?"))
   }
 }
 
@@ -42,7 +41,7 @@ test_that("ds_create_dataset gives back expected class types", {
 
   a <- ds_create_dataset(package_id=did, name=ds_title, file, key, url)
   expect_is(a, "list")
-  expect_is(a$resource_group_id, "character")
+  expect_is(a$name, "character")
 })
 
 test_that("ds_create_dataset gives back expected output", {
@@ -66,6 +65,6 @@ test_that("ds_create_dataset fails well", {
   expect_error(ds_create_dataset(did, ds_title, file, "badkey", url),
                "Forbidden")
   # bad file path
-  expect_error(ds_create_dataset(ds_slug, ds_title, "asdfasdf", key, url),
+  expect_error(ds_create_dataset(did, ds_title, "asdfasdf", key, url),
                "file does not exist")
 })

--- a/tests/testthat/test-resource_update.R
+++ b/tests/testthat/test-resource_update.R
@@ -15,17 +15,18 @@ test_that("A CKAN resource ID must be set", { expect_is(rid, "character") })
 # Helper functions to test CKAN environment
 check_ckan <- function(){
   if(!ping(url)) {
-    skip(paste0("CKAN is offline. Tests for resource_update require a live ",
-                "CKAN URL to be set with set_ckanr_url('your_ckan_url')."))
+    skip(paste("CKAN is offline.",
+               "Did you set CKAN test settings with ?set_test_env ?",
+               "Does the test CKAN server run at", url, "?"))
   }
 }
 
 check_resource <- function(){
   res <- resource_show(rid, url=url)
-  if(class(res)!="list"){
-   skip(paste0("The CKAN resource doesn't seem to exist. Tests for ",
-               "resource_update require an existing CKAN resource ID to be",
-               "consult ?set_test_env"))
+  if(class(res)!="list" && res$id!=rid){
+   skip(paste("The CKAN test resource wasn't found.",
+               "Did you set CKAN test settings with ?set_test_env ?",
+               "Does Resource with ID", rid, "exist on", url, "?"))
   }
 }
 


### PR DESCRIPTION
This PR addresses #30 

Tests like `test-resource_update.R` require write access to a CKAN instance. At least a URL, an API key, an existing dataset ID and an existing resource ID (attached to dataset ID) must be given. Testthat apparently can't access options(), but can get to Sys.env.

`ckan_options.R`: `set_test_env()` now writes test server settings to both options (so `ckanr_options()` can print them) and Sys.env.

The "non-readonly" tests pass when run with `test_file("tests/testthat/test-{resource_update, ds_create_dataset}.R")` but skip when run with devtools::test().

devtools::check() runs successfully with 1 (unrelated) warning about `print.ckanr_options`.

Running the "non-readonly" test requires:
```{R}
# set environment for package ckanr
set_test_env("http://my.test.ckan.org/",
             "my-test-ckan-api-key",
             "my-test-dataset-id",
             "my-test-resource-id")
```