### PR TITLE
solves #34 removed unused argument "key" from package_show and resource_show

### DIFF
--- a/R/ds_create_dataset.R
+++ b/R/ds_create_dataset.R
@@ -1,27 +1,42 @@
-#' Datastore - create a dataset
+#' Datastore - create a new resource on an existing dataset
 #'
 #' @export
 #' @importFrom httr upload_file add_headers POST
 #'
-#' @param package_id (character) Existing package ID to add a resource to (required)
+#' @param package_id (character) Existing package ID (required)
 #' @param name (character) Name of the new resource (required)
 #' @param path (character) Path of the file to add (required)
-#' @param key API key (required)
+#' @template key
 #' @template args
 #' @references
 #' \url{http://docs.ckan.org/en/latest/api/index.html#ckan.logic.action.create.resource_create}
 #' @examples \dontrun{
-#' file <- system.file("examples", "actinidiaceae.csv", package = "ckanr")
-#' key <- getOption('ckan_demo_key')
-#' ds_create_dataset(package_id='testingagain', name="mydata", path=file, key)
+#' path <- system.file("examples", "actinidiaceae.csv", package = "ckanr")
+#' set_ckanr_url("http://demo.ckan.org/")
+#' set_api_key("my-demo-ckan-org-api-key")
+#' ds_create_dataset(package_id='testingagain', name="mydata", path=path)
+#'
+#' # Testing: see ?set_test_env to set default test CKAN url, key, package id
+#' set_test_env("http://my-ckan.org/", "my-ckan-api-key",
+#'              "an-existing-package-id", "an-existing-resource-id")
+#' ds_create_dataset(package_id=get_test_pid(), name="mydata",
+#'                   path=system.file("examples",
+#'                                    "actinidiaceae.csv",
+#'                                    package = "ckanr"),
+#'                   key=get_test_key(),
+#'                   url=get_test_url())
 #' }
-ds_create_dataset <- function(package_id, name, path, key,
-                              url = 'http://demo.ckan.org', as = 'list', ...) {
+ds_create_dataset <- function(package_id, name, path,
+                              key=getOption("X-CKAN-API-Key"),
+                              url=get_ckanr_url(),
+                              as = 'list', ...) {
   path <- path.expand(path)
   ext <- strsplit(basename(path), "\\.")[[1]]
   ext <- ext[length(ext)]
-  body <- list(package_id = package_id, name = name, format = ext, url = 'upload', upload = upload_file(path))
-  res <- POST(file.path(url, ck(), 'resource_create'), add_headers(Authorization = key), body = body, ...)
+  body <- list(package_id = package_id, name = name, format = ext,
+               url = 'upload', upload = upload_file(path))
+  res <- POST(file.path(url, ck(), 'resource_create'),
+              add_headers(Authorization = key), body = body, ...)
   stop_for_status(res)
   res <- content(res, "text")
   switch(as, json = res, list = jsl(res), table = jsd(res))
@@ -32,16 +47,20 @@ ds_create_dataset <- function(package_id, name, path, key,
 #' BEWARE: This function still doesn't quite work yet.
 #'
 #' @export
-#' @param resource_id (string) Resource id that the data is going to be stored against.
-#' @param force (logical) Set to \code{TRUE} to edit a read-only resource. Default: FALSE
-#' @param resource (dictionary) Resource dictionary that is passed to resource_create().
-#' Use instead of \code{resource_id} (optional)
-#' @param aliases (character) Names for read only aliases of the resource. (optional)
+#' @param resource_id (string) Resource id that the data is going to be stored
+#'   against.
+#' @param force (logical) Set to \code{TRUE} to edit a read-only resource.
+#'   Default: FALSE
+#' @param resource (dictionary) Resource dictionary that is passed to
+#'   resource_create(). Use instead of \code{resource_id} (optional)
+#' @param aliases (character) Names for read only aliases of the resource.
+#'   (optional)
 #' @param fields (list) Fields/columns and their extra metadata. (optional)
-#' @param records (list) The data, eg: \code{[{"dob": "2005", "some_stuff": ["a", "b"]}]} (optional)
+#' @param records (list) The data, eg: \code{[{"dob": "2005", "some_stuff":
+#'   ["a", "b"]}]} (optional)
 #' @param primary_key (character) Fields that represent a unique key (optional)
 #' @param indexes (character) Indexes on table (optional)
-#' @param key API key (required)
+#' @template key
 #' @template args
 #' @references \url{http://bit.ly/1G9cnBl}
 #' @examples \dontrun{
@@ -49,13 +68,19 @@ ds_create_dataset <- function(package_id, name, path, key,
 #'          records=iris, force = TRUE, key=getOption('ckan_demo_key'))
 #' }
 
-ds_create <- function(resource_id = NULL, resource = NULL, force = FALSE, aliases = NULL,
-  fields = NULL, records = NULL, primary_key = NULL, indexes = NULL,
-  key, url = 'http://demo.ckan.org', as = 'list', ...) {
+ds_create <- function(resource_id = NULL, resource = NULL, force = FALSE,
+                      aliases = NULL, fields = NULL, records = NULL,
+                      primary_key = NULL, indexes = NULL,
+                      key=getOption("X-CKAN-API-Key"),
+                      url=get_ckanr_url(),
+                      as = 'list', ...) {
 
-  body <- cc(list(resource_id = resource_id, resource = resource, force = force, aliases = aliases,
-               fields = fields, records = convert(records), primary_key = primary_key, indexes = indexes))
-  res <- POST(file.path(url, 'api/action/datastore_create'), add_headers(Authorization = key), body = body, ...)
+  body <- cc(list(resource_id = resource_id, resource = resource, force = force,
+                  aliases = aliases, fields = fields, records = convert(records),
+                  primary_key = primary_key, indexes = indexes))
+  res <- POST(file.path(url, 'api/action/datastore_create'),
+              add_headers(Authorization = key),
+              body = body, ...)
   stop_for_status(res)
   res <- content(res, "text")
   switch(as, json = res, list = jsl(res), table = jsd(res))

--- a/R/package_show.R
+++ b/R/package_show.R
@@ -3,20 +3,22 @@
 #' @export
 #'
 #' @param id (character) Package identifier.
-#' @param use_default_schema (logical) Use default package schema instead of a custom
-#' schema defined with an IDatasetForm plugin. Default: FALSE
+#' @param use_default_schema (logical) Use default package schema instead of a
+#'   custom schema defined with an IDatasetForm plugin. Default: FALSE
 #' @template args
-#' @details By default the help and success slots are dropped, and only the result
-#' slot is returned. You can request raw json with \code{as='json'} then parse yourself
-#' to get the help slot.
+#' @details By default the help and success slots are dropped, and only the
+#'   result slot is returned. You can request raw json with \code{as='json'}
+#'   then parse yourself to get the help slot.
 #' @examples \dontrun{
 #' package_show('34d60b13-1fd5-430e-b0ec-c8bc7f4841cf')
 #' package_show('34d60b13-1fd5-430e-b0ec-c8bc7f4841cf', as='json')
 #' package_show('34d60b13-1fd5-430e-b0ec-c8bc7f4841cf', as='table')
 #' package_show('34d60b13-1fd5-430e-b0ec-c8bc7f4841cf', TRUE)
 #' }
-package_show <- function(id, use_default_schema = FALSE, url = get_ckanr_url(),
-                         key = NULL, as='list', ...) {
+package_show <- function(id,
+                         use_default_schema = FALSE,
+                         url = get_ckanr_url(),
+                         as='list', ...) {
   body <- cc(list(id = id, use_default_schema = use_default_schema))
   res <- ckan_POST(url, 'package_show', body = body, key = key, ...)
   switch(as, json = res, list = jsl(res), table = jsd(res))

--- a/R/package_show.R
+++ b/R/package_show.R
@@ -20,6 +20,6 @@ package_show <- function(id,
                          url = get_ckanr_url(),
                          as='list', ...) {
   body <- cc(list(id = id, use_default_schema = use_default_schema))
-  res <- ckan_POST(url, 'package_show', body = body, key = key, ...)
+  res <- ckan_POST(url, 'package_show', body = body, ...)
   switch(as, json = res, list = jsl(res), table = jsd(res))
 }

--- a/R/resource_show.R
+++ b/R/resource_show.R
@@ -8,8 +8,8 @@
 #' resource_show(id = "e179e910-27fb-44f4-a627-99822af49ffa", as="table")
 #' resource_show(id = "05ff2255-c38a-40c9-b657-4ccb55ab2feb", url = "http://data.nhm.ac.uk")
 #' }
-resource_show <- function(id, url = get_ckanr_url(), as = 'list', key = NULL, ...) {
-  res <- ckan_POST(url, 'resource_show', body = list(id = id), key = key, ...)
+resource_show <- function(id, url = get_ckanr_url(), as = 'list', ...) {
+  res <- ckan_POST(url, 'resource_show', body = list(id = id), ...)
   switch(as, json = res, list = jsl(res), table = jsd(res))
 }
 

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -17,8 +17,7 @@
 #'
 #' @param id (character) Resource ID to update (required)
 #' @param path (character) Local path of the file to upload (required)
-#' @param key A CKAN API key with write permissions to the resource's dataset
-#'    (default: \code{api_key()})
+#' @template key
 #' @template args
 #' @return The HTTP response from CKAN, formatted as list (default), table, or JSON.
 #' @references
@@ -27,8 +26,11 @@
 #' # Using an existing file and explicit CKAN URL and API key
 #' # Note: enter valid values for id, url, and key
 #' resource_update(id="an-existing-resource-id",
-#'                 path=system.file("examples", "actinidiaceae.csv", package = "ckanr"),
-#'                 url="http://my-ckan-instance.org/", key="my-ckan-api-key")
+#'                 path=system.file("examples",
+#'                                  "actinidiaceae.csv",
+#'                                  package = "ckanr"),
+#'                 key="my-ckan-api-key",
+#'                 url="http://my-ckan-instance.org/")
 #'
 #' # Using an R object written to a tempfile, and implicit CKAN URL and API key
 #' data <- installed.packages()
@@ -37,10 +39,20 @@
 #' set_ckanr_url("http://demo.ckan.org/")
 #' set_api_key("my-demo-ckan-org-api-key")
 #' resource_update(id="an-existing-resource-id", path=path)
+#'
+#' # Testing: see ?set_test_env to set default test CKAN url, key, package id
+#' set_test_env("http://my-ckan.org/", "my-ckan-api-key",
+#'              "an-existing-package-id", "an-existing-resource-id")
+#' resource_update(id=get_test_rid(),
+#'                 path=system.file("examples",
+#'                                  "actinidiaceae.csv",
+#'                                  package = "ckanr"),
+#'                 key=get_test_key(),
+#'                 url=get_test_url())
 #' }
 resource_update <- function(id, path,
-                            url=get_ckanr_url(),
                             key=getOption("X-CKAN-API-Key"),
+                            url=get_ckanr_url(),
                             as = 'list', ...) {
   path <- path.expand(path)
   body <- list(id = id,

--- a/man-roxygen/key.R
+++ b/man-roxygen/key.R
@@ -1,0 +1,1 @@
+#' @param key A privileged CKAN API key, default: your key set with \code{set_api_key()}

--- a/man/ds_create.Rd
+++ b/man/ds_create.Rd
@@ -6,27 +6,32 @@
 \usage{
 ds_create(resource_id = NULL, resource = NULL, force = FALSE,
   aliases = NULL, fields = NULL, records = NULL, primary_key = NULL,
-  indexes = NULL, key, url = "http://demo.ckan.org", as = "list", ...)
+  indexes = NULL, key = getOption("X-CKAN-API-Key"),
+  url = get_ckanr_url(), as = "list", ...)
 }
 \arguments{
-\item{resource_id}{(string) Resource id that the data is going to be stored against.}
+\item{resource_id}{(string) Resource id that the data is going to be stored
+against.}
 
-\item{resource}{(dictionary) Resource dictionary that is passed to resource_create().
-Use instead of \code{resource_id} (optional)}
+\item{resource}{(dictionary) Resource dictionary that is passed to
+resource_create(). Use instead of \code{resource_id} (optional)}
 
-\item{force}{(logical) Set to \code{TRUE} to edit a read-only resource. Default: FALSE}
+\item{force}{(logical) Set to \code{TRUE} to edit a read-only resource.
+Default: FALSE}
 
-\item{aliases}{(character) Names for read only aliases of the resource. (optional)}
+\item{aliases}{(character) Names for read only aliases of the resource.
+(optional)}
 
 \item{fields}{(list) Fields/columns and their extra metadata. (optional)}
 
-\item{records}{(list) The data, eg: \code{[{"dob": "2005", "some_stuff": ["a", "b"]}]} (optional)}
+\item{records}{(list) The data, eg: \code{[{"dob": "2005", "some_stuff":
+["a", "b"]}]} (optional)}
 
 \item{primary_key}{(character) Fields that represent a unique key (optional)}
 
 \item{indexes}{(character) Indexes on table (optional)}
 
-\item{key}{API key (required)}
+\item{key}{A privileged CKAN API key, default: your key set with \code{set_api_key()}}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{get_ckanr_url}} and \code{\link{set_ckanr_url}}}

--- a/man/ds_create_dataset.Rd
+++ b/man/ds_create_dataset.Rd
@@ -2,19 +2,19 @@
 % Please edit documentation in R/ds_create_dataset.R
 \name{ds_create_dataset}
 \alias{ds_create_dataset}
-\title{Datastore - create a dataset}
+\title{Datastore - create a new resource on an existing dataset}
 \usage{
-ds_create_dataset(package_id, name, path, key, url = "http://demo.ckan.org",
-  as = "list", ...)
+ds_create_dataset(package_id, name, path, key = getOption("X-CKAN-API-Key"),
+  url = get_ckanr_url(), as = "list", ...)
 }
 \arguments{
-\item{package_id}{(character) Existing package ID to add a resource to (required)}
+\item{package_id}{(character) Existing package ID (required)}
 
 \item{name}{(character) Name of the new resource (required)}
 
 \item{path}{(character) Path of the file to add (required)}
 
-\item{key}{API key (required)}
+\item{key}{A privileged CKAN API key, default: your key set with \code{set_api_key()}}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{get_ckanr_url}} and \code{\link{set_ckanr_url}}}
@@ -26,13 +26,24 @@ data to data.frame's when possible, so the result can vary. (required)}
 \item{...}{Curl args passed on to \code{\link[httr]{POST}} (optional)}
 }
 \description{
-Datastore - create a dataset
+Datastore - create a new resource on an existing dataset
 }
 \examples{
 \dontrun{
-file <- system.file("examples", "actinidiaceae.csv", package = "ckanr")
-key <- getOption('ckan_demo_key')
-ds_create_dataset(package_id='testingagain', name="mydata", path=file, key)
+path <- system.file("examples", "actinidiaceae.csv", package = "ckanr")
+set_ckanr_url("http://demo.ckan.org/")
+set_api_key("my-demo-ckan-org-api-key")
+ds_create_dataset(package_id='testingagain', name="mydata", path=path)
+
+# Testing: see ?set_test_env to set default test CKAN url, key, package id
+set_test_env("http://my-ckan.org/", "my-ckan-api-key",
+             "an-existing-package-id", "an-existing-resource-id")
+ds_create_dataset(package_id=get_test_pid(), name="mydata",
+                  path=system.file("examples",
+                                   "actinidiaceae.csv",
+                                   package = "ckanr"),
+                  key=get_test_key(),
+                  url=get_test_url())
 }
 }
 \references{

--- a/man/package_show.Rd
+++ b/man/package_show.Rd
@@ -5,13 +5,13 @@
 \title{Show a package.}
 \usage{
 package_show(id, use_default_schema = FALSE, url = get_ckanr_url(),
-  key = NULL, as = "list", ...)
+  as = "list", ...)
 }
 \arguments{
 \item{id}{(character) Package identifier.}
 
-\item{use_default_schema}{(logical) Use default package schema instead of a custom
-schema defined with an IDatasetForm plugin. Default: FALSE}
+\item{use_default_schema}{(logical) Use default package schema instead of a
+custom schema defined with an IDatasetForm plugin. Default: FALSE}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{get_ckanr_url}} and \code{\link{set_ckanr_url}}}
@@ -26,9 +26,9 @@ data to data.frame's when possible, so the result can vary. (required)}
 Show a package.
 }
 \details{
-By default the help and success slots are dropped, and only the result
-slot is returned. You can request raw json with \code{as='json'} then parse yourself
-to get the help slot.
+By default the help and success slots are dropped, and only the
+  result slot is returned. You can request raw json with \code{as='json'}
+  then parse yourself to get the help slot.
 }
 \examples{
 \dontrun{

--- a/man/resource_show.Rd
+++ b/man/resource_show.Rd
@@ -4,7 +4,7 @@
 \alias{resource_show}
 \title{Show a resource.}
 \usage{
-resource_show(id, url = get_ckanr_url(), as = "list", key = NULL, ...)
+resource_show(id, url = get_ckanr_url(), as = "list", ...)
 }
 \arguments{
 \item{id}{(character) Resource identifier.}

--- a/man/resource_update.Rd
+++ b/man/resource_update.Rd
@@ -4,19 +4,18 @@
 \alias{resource_update}
 \title{Update a resource's file attachment}
 \usage{
-resource_update(id, path, url = get_ckanr_url(),
-  key = getOption("X-CKAN-API-Key"), as = "list", ...)
+resource_update(id, path, key = getOption("X-CKAN-API-Key"),
+  url = get_ckanr_url(), as = "list", ...)
 }
 \arguments{
 \item{id}{(character) Resource ID to update (required)}
 
 \item{path}{(character) Local path of the file to upload (required)}
 
+\item{key}{A privileged CKAN API key, default: your key set with \code{set_api_key()}}
+
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{get_ckanr_url}} and \code{\link{set_ckanr_url}}}
-
-\item{key}{A CKAN API key with write permissions to the resource's dataset
-(default: \code{api_key()})}
 
 \item{as}{(character) One of list (default), table, or json. Parsing with table option
 uses \code{jsonlite::fromJSON(..., simplifyDataFrame = TRUE)}, which attempts to parse
@@ -45,8 +44,11 @@ which are set by \code{set_ckanr_url("http://my-ckan.org/")} and
 # Using an existing file and explicit CKAN URL and API key
 # Note: enter valid values for id, url, and key
 resource_update(id="an-existing-resource-id",
-                path=system.file("examples", "actinidiaceae.csv", package = "ckanr"),
-                url="http://my-ckan-instance.org/", key="my-ckan-api-key")
+                path=system.file("examples",
+                                 "actinidiaceae.csv",
+                                 package = "ckanr"),
+                key="my-ckan-api-key",
+                url="http://my-ckan-instance.org/")
 
 # Using an R object written to a tempfile, and implicit CKAN URL and API key
 data <- installed.packages()
@@ -55,6 +57,16 @@ write.csv(data, path)
 set_ckanr_url("http://demo.ckan.org/")
 set_api_key("my-demo-ckan-org-api-key")
 resource_update(id="an-existing-resource-id", path=path)
+
+# Testing: see ?set_test_env to set default test CKAN url, key, package id
+set_test_env("http://my-ckan.org/", "my-ckan-api-key",
+             "an-existing-package-id", "an-existing-resource-id")
+resource_update(id=get_test_rid(),
+                path=system.file("examples",
+                                 "actinidiaceae.csv",
+                                 package = "ckanr"),
+                key=get_test_key(),
+                url=get_test_url())
 }
 }
 \references{


### PR DESCRIPTION
addressing #34 

Thanks to `@template args`, `url`, `as` and `...` are already documented. Streamlined api key docstring into `@template key` and did some reformatting (hope that's ok).

Edit: I don't fully understand how coveralls finds that this PR reduces the test coveage by 10%.
