### PR TITLE
added parameter include_datasets=FALSE to tag_show to match CKAN API

### DIFF
--- a/R/tag_show.R
+++ b/R/tag_show.R
@@ -3,13 +3,17 @@
 #' @export
 #'
 #' @param id (character) The name or id of the tag
+#' @param include_datasets include a list of up to 1000 of the tag’s datasets.
+#'  Limit 1000 datasets, use `package_search` for more. (optional, default: False)
 #' @template args
 #' @examples \dontrun{
 #' tag_show('Aviation')
 #' tag_show('Aviation', as = 'json')
 #' tag_show('Aviation', as = 'table')
 #' }
-tag_show <- function(id, url = get_default_url(), as = 'list', ...) {
-  res <- ckan_POST(url, 'tag_show', body = list(id = id), ...)
+tag_show <- function(id, include_datasets = FALSE, url = get_default_url(),
+                     as = 'list', ...) {
+  res <- ckan_POST(url, 'tag_show',
+                   body = list(id = id, include_datasets = include_datasets), ...)
   switch(as, json = res, list = jsl(res), table = jsd(res))
 }

--- a/man/tag_show.Rd
+++ b/man/tag_show.Rd
@@ -4,10 +4,14 @@
 \alias{tag_show}
 \title{Show a tag.}
 \usage{
-tag_show(id, url = get_default_url(), as = "list", ...)
+tag_show(id, include_datasets = FALSE, url = get_default_url(),
+  as = "list", ...)
 }
 \arguments{
 \item{id}{(character) The name or id of the tag}
+
+\item{include_datasets}{include a list of up to 1000 of the tag’s datasets.
+Limit 1000 datasets, use `package_search` for more. (optional, default: False)}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{ckanr_setup}} and \code{\link{get_default_url}}.}

--- a/tests/testthat/test-tag_show.R
+++ b/tests/testthat/test-tag_show.R
@@ -11,7 +11,7 @@ tag_test_num <- local({
 
 test_that("tag_show gives back expected class types", {
   check_ckan(u)
-  a <- tag_show("test", url=u)
+  a <- tag_show("test", include_datasets = TRUE, url=u)
 
   expect_is(a, "list")
   expect_is(a[[2]], "list")
@@ -20,7 +20,7 @@ test_that("tag_show gives back expected class types", {
 
 test_that("tag_show works giving back json output", {
   check_ckan(u)
-  b <- tag_show("test", url=u, as = 'json')
+  b <- tag_show("test", include_datasets = TRUE, url=u, as = 'json')
   b_df <- jsonlite::fromJSON(b)
   expect_is(b, "character")
   expect_is(b_df, "list")


### PR DESCRIPTION
Addressing #41 tests pass again with Travis's test server settings (data-demo.dpaw.wa.gov.au).