### PR TITLE
fix #64 by adding resource formats

### DIFF
--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -84,5 +84,6 @@ resource_update <- function(id, path, key = get_default_key(),
 
 pick_type <- function(x) {
   switch(x,
-         `text/csv` = "csv")
+         `text/csv` = "csv",
+         `text/html` = "html")
 }

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -84,6 +84,17 @@ resource_update <- function(id, path, key = get_default_key(),
 
 pick_type <- function(x) {
   switch(x,
+         `text/html` = "html",
          `text/csv` = "csv",
-         `text/html` = "html")
+         `text/plain` = "txt",
+         `application/vnd.openxmlformats-officedocument.wordprocessingml.document` = "docx",
+         `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` = "xlsx",
+         `application/vnd.ms-excel.sheet.macroEnabled.12` = "xlsm",
+         `application/json` = "json",
+         `application/vnd.geo+json` = "geojson",
+         `application/pdf` = "pdf",
+         `image/jpeg` = "jpeg",
+         `image/png` = "png",
+         `image/bmp` = "bmp"
+         )
 }


### PR DESCRIPTION
Fix #64 

This PR adds a handful of resource formats to `resource_update`'s lookup helper, covering my use cases. 

This PR will primarily serve users who use `ckanr` to grab data from CKAN, produce some data products (figures as png/jpeg/png/pdf, data as csv/xlsx) and finally want to upload the products (and why not the code as text / RMarkdown workbook as html output while we're at it) back to a CKAN dataset.

More formats to be added:

* formats supported by CKAN previews (some MS office formats might be missing)
* [custom mimetypes](http://docs.ckan.org/en/latest/maintaining/filestore.html#custom-internet-media-types-mime-types) defined in CKAN extensions
* ckanext-ecportal's [mime types](https://github.com/okfn/ckanext-ecportal/blob/master/data/resource_mapping.json) and [dropdown options](https://github.com/okfn/ckanext-ecportal/blob/master/data/resource_dropdown.json)
* ckanext-dgu's [mimetypes](https://github.com/datagovuk/ckanext-dgu/blob/master/ckanext/dgu/lib/formats.py#L88)

Follow-up: add tests for all configured file types - where should we source the example files from? Should we include smallest possible example files into `data/`?