### PR TITLE
Update ds_create method to properly format body with json data

### DIFF
--- a/R/ds_create.R
+++ b/R/ds_create.R
@@ -42,11 +42,12 @@ ds_create <- function(resource_id = NULL, resource = NULL, force = FALSE,
                       url = get_default_url(), as = 'list', ...) {
 
   body <- cc(list(resource_id = resource_id, resource = resource, force = force,
-                  aliases = aliases, fields = fields, records = convert(records),
+                  aliases = aliases, fields = fields, records = records,
                   primary_key = primary_key, indexes = indexes))
   res <- POST(file.path(url, 'api/action/datastore_create'),
               add_headers(Authorization = key),
-              body = body, ...)
+              body = tojun(body, TRUE),
+              encode = "json", ctj(), ...)
   stop_for_status(res)
   res <- content(res, "text", encoding = "UTF-8")
   switch(as, json = res, list = jsl(res), table = jsd(res))


### PR DESCRIPTION
This pull request brings the ds_create method to the point where it can insert records in the datastore resource.

@sckott I may have the chance to work a lot with this at the moment and would be up for filling in the gaps in and documenting the Datastore API. As I am not an R expert it might help me a lot if we could talk for 15m sometime to get a crash course on HTTP calls in R, package conventions, etc.