### PR TITLE
Updates to ckan_fetch() and examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Imports:
     magrittr
 Suggests:
     knitr,
-    maptools,
+    sf,
     readxl,
     testthat,
     xml2,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     testthat,
     xml2,
     lazyeval
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 X-schema.org-keywords: database, open-data, ckan, api, data, dataset
 X-schema.org-applicationCategory: Data Access
 X-schema.org-isPartOf: "https://ropensci.org"

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -59,6 +59,10 @@ read_session <- function(fmt, dat, path) {
            check4X("readxl")
            readxl::read_excel(path)
          },
+         xlsx = {
+           check4X("readxl")
+           readxl::read_excel(path)
+         },
          xml = {
            check4X("xml2")
            xml2::read_xml(dat)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -8,36 +8,37 @@
 #' @param path if store=disk, you must give a path to store file to
 #' @param ... Curl arguments passed on to \code{\link[httr]{GET}}
 #' @examples \dontrun{
+#' # CSV file
 #' ckanr_setup('http://datamx.io')
 #' res <- resource_show(id = "6145a539-cbde-4b0d-a3d3-d1a5eb013f5c", as = "table")
 #' head(ckan_fetch(res$url))
 #' ckan_fetch(res$url, "disk", "myfile.csv")
 #'
 #' # Excel file - requires readxl package
-#' ckanr_setup()
-#' res <- resource_show(id = "f4f871ae-139f-4acd-a700-8a08a1a04f95", as = "table")
+#' ckanr_setup('http://datamx.io')
+#' res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
 #' head(ckan_fetch(res$url))
 #'
 #' # XML file
-#' ckanr_setup("http://publicdata.eu/")
-#' res <- resource_show(id = "ba447d6b-271e-42c2-965e-945f8e26b2ff", as = "table")
+#' ckanr_setup("http://data.ottawa.ca")
+#' res <- resource_show(id = "380061c1-6c46-4da6-a01b-7ab0f49a881e", as = "table")
 #' ckan_fetch(res$url)
 #'
 #' # HTML file
-#' ckanr_setup("http://publicdata.eu/")
-#' res <- resource_show(id = "9b5bebd8-ff40-476c-beeb-aae172031d5f", as = "table")
+#' ckanr_setup("http://open.canada.ca/data/en")
+#' res <- resource_show(id = "80321bac-4283-487c-93bd-c65acaa660f5", as = "table")
 #' ckan_fetch(res$url)
 #' library("xml2")
-#' xml_text(xml_find_one(xml_children(ckan_fetch(res$url))[[1]], "title"))
+#' xml_text(xml_find_first(xml_children(ckan_fetch(res$url))[[1]], "title"))
 #'
 #' # JSON file, by default reads in to a data.frame for ease of use
-#' ckanr_setup("http://publicdata.eu/")
-#' res <- resource_show(id = "fa268f29-5e19-4402-a014-3e0fb93936a8", as = "table")
+#' ckanr_setup("http://data.surrey.ca")
+#' res <- resource_show(id = "8d07c662-800d-4977-9e3e-5a3d2d1e99ab", as = "table")
 #' head(ckan_fetch(res$url))
 #'
 #' # SHP file (spatial data, ESRI format)
-#' ckanr_setup("http://publicdata.eu/")
-#' res <- resource_show(id = "7618b8e2-7308-4964-8024-f13df166e7fd", as = "table")
+#' ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
+#' res <- resource_show(id = "6cbb0aa3-a8d1-421c-9c40-14c6f05e0c73", as = "table")
 #' x <- ckan_fetch(res$url)
 #' class(x)
 #' plot(x)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -69,8 +69,8 @@ read_session <- function(fmt, dat, path) {
          },
          json = jsonlite::fromJSON(dat),
          shp = {
-           check4X("maptools")
-           maptools::readShapePoints(path)
+           check4X("sf")
+           sf::st_read(path)
          }
   )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -40,11 +40,11 @@ ckan_VERB <- function(verb, url, method, body, key, ...) {
     # authentication
     api_key_header <- add_headers("X-CKAN-API-Key" = key)
     if (is.null(body) || length(body) == 0) {
-      res <- VERB(file.path(url, ck(), method), ctj(), 
+      res <- VERB(file.path(url, ck(), method), ctj(),
         api_key_header, proxy, ...)
         # api_key_header, config = httr::config(proxy, ...))
     } else {
-      res <- VERB(file.path(url, ck(), method), body = body, 
+      res <- VERB(file.path(url, ck(), method), body = body,
         api_key_header, proxy, ...)
         # api_key_header, config = httr::config(proxy, ...))
     }
@@ -63,10 +63,10 @@ fetch_GET <- function(x, store, path, args = NULL, ...) {
     }
   }
   if (store == "session") {
-    if (file_fmt(x) == "xls") {
+    if (file_fmt(x) %in% c("xls", "xlsx")) {
       fmt <- file_fmt(x)
       dat <- NULL
-      path <- paste0(path, ".xls")
+      path <- paste0(path, ".", fmt)
       res <- GET(x, query = args, write_disk(path, TRUE), config = proxy, ...)
       path <- res$request$output$path
     } else if (file_fmt(x) %in% c("shp", "zip")) {

--- a/codemeta.json
+++ b/codemeta.json
@@ -1,20 +1,23 @@
 {
-  "@context": ["https://doi.org/doi:10.5063/schema/codemeta-2.0", "http://schema.org"],
+  "@context": [
+    "https://doi.org/doi:10.5063/schema/codemeta-2.0",
+    "http://schema.org"
+  ],
   "@type": "SoftwareSourceCode",
   "identifier": "ckanr",
-  "description": "Client for 'CKAN' 'API' (http://ckan.org/). Includes interface\n    to 'CKAN' 'APIs' for search, list, show for packages, organizations, and\n    resources. In addition, provides an interface to the 'datastore' 'API'.",
-  "name": "ckanr: Client for the Comprehensive Knowledge Archive Network ('CKAN') 'API'",
-  "codeRepository": "https://github.com/ropensci/ckanr.git",
-  "issueTracker": "http://www.github.com/ropensci/ckanr/issues",
+  "description": "Client for 'CKAN' API (http://ckan.org/). Includes interface\n    to 'CKAN' 'APIs' for search, list, show for packages, organizations, and\n    resources. In addition, provides an interface to the 'datastore' API.",
+  "name": "ckanr: Client for the Comprehensive Knowledge Archive Network ('CKAN') API",
+  "codeRepository": "https://github.com/ropensci/ckanr",
+  "issueTracker": "https://github.com/ropensci/ckanr/issues",
   "license": "https://spdx.org/licenses/MIT",
-  "version": "0.1.2.9846",
+  "version": "0.1.2.9924",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.3.2",
+    "version": "3.5.2",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.3.2 (2016-10-31)",
+  "runtimePlatform": "R version 3.5.2 (2018-12-20)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -51,13 +54,15 @@
       "@id": "http://orcid.org/0000-0003-4269-4242"
     }
   ],
-  "maintainer": {
-    "@type": "Person",
-    "givenName": "Scott",
-    "familyName": "Chamberlain",
-    "email": "myrmecocystus@gmail.com",
-    "@id": "http://orcid.org/0000-0003-1444-9135"
-  },
+  "maintainer": [
+    {
+      "@type": "Person",
+      "givenName": "Scott",
+      "familyName": "Chamberlain",
+      "email": "myrmecocystus@gmail.com",
+      "@id": "http://orcid.org/0000-0003-1444-9135"
+    }
+  ],
   "softwareSuggestions": [
     {
       "@type": "SoftwareApplication",
@@ -66,20 +71,22 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=knitr"
     },
     {
       "@type": "SoftwareApplication",
-      "identifier": "maptools",
-      "name": "maptools",
+      "identifier": "sf",
+      "name": "sf",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=sf"
     },
     {
       "@type": "SoftwareApplication",
@@ -88,9 +95,10 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=readxl"
     },
     {
       "@type": "SoftwareApplication",
@@ -99,9 +107,10 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=testthat"
     },
     {
       "@type": "SoftwareApplication",
@@ -110,9 +119,10 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=xml2"
     },
     {
       "@type": "SoftwareApplication",
@@ -121,12 +131,26 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=lazyeval"
     }
   ],
   "softwareRequirements": [
+    {
+      "@type": "SoftwareApplication",
+      "identifier": "DBI",
+      "name": "DBI",
+      "version": ">= 0.3.1",
+      "provider": {
+        "@id": "https://cran.r-project.org",
+        "@type": "Organization",
+        "name": "Comprehensive R Archive Network (CRAN)",
+        "url": "https://cran.r-project.org"
+      },
+      "sameAs": "https://CRAN.R-project.org/package=DBI"
+    },
     {
       "@type": "SoftwareApplication",
       "identifier": "methods",
@@ -146,37 +170,40 @@
       "@type": "SoftwareApplication",
       "identifier": "httr",
       "name": "httr",
-      "version": "1.0.0",
+      "version": ">= 1.0.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=httr"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "jsonlite",
       "name": "jsonlite",
-      "version": "0.9.17",
+      "version": ">= 0.9.17",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=jsonlite"
     },
     {
       "@type": "SoftwareApplication",
       "identifier": "dplyr",
       "name": "dplyr",
-      "version": "0.7.0",
+      "version": ">= 0.7.0",
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=dplyr"
     },
     {
       "@type": "SoftwareApplication",
@@ -185,9 +212,10 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=dbplyr"
     },
     {
       "@type": "SoftwareApplication",
@@ -196,28 +224,19 @@
       "provider": {
         "@id": "https://cran.r-project.org",
         "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
+        "name": "Comprehensive R Archive Network (CRAN)",
         "url": "https://cran.r-project.org"
-      }
-    },
-    {
-      "@type": "SoftwareApplication",
-      "identifier": "DBI",
-      "name": "DBI",
-      "version": "0.3.1",
-      "provider": {
-        "@id": "https://cran.r-project.org",
-        "@type": "Organization",
-        "name": "Central R Archive Network (CRAN)",
-        "url": "https://cran.r-project.org"
-      }
+      },
+      "sameAs": "https://CRAN.R-project.org/package=magrittr"
     }
   ],
   "applicationCategory": "DataAccess",
   "isPartOf": "\"https://ropensci.org\"",
-  "keywords": ["database", "open-data", "ckan", "api", "data", "dataset"],
+  "keywords": ["database", "open-data", "ckan", "api", "data", "dataset", "ckan-api", "api-wrapper", "r", "rstats", "r-package"],
   "contIntegration": "https://travis-ci.org/ropensci/ckanr",
-  "releaseNotes": "https://github.com/ropensci/ckanr.git/blob/master/NEWS.md",
-  "readme": "https://github.com/ropensci/ckanr.git/blob/master/README.md",
-  "fileSize": "72.757KB"
+  "releaseNotes": "https://github.com/ropensci/ckanr/blob/master/NEWS.md",
+  "readme": "https://github.com/ropensci/ckanr/blob/master/README.md",
+  "fileSize": "2771.562KB",
+  "copyrightHolder": {},
+  "funder": {}
 }

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -21,36 +21,37 @@ Download a file
 }
 \examples{
 \dontrun{
+# CSV file
 ckanr_setup('http://datamx.io')
 res <- resource_show(id = "6145a539-cbde-4b0d-a3d3-d1a5eb013f5c", as = "table")
 head(ckan_fetch(res$url))
 ckan_fetch(res$url, "disk", "myfile.csv")
 
 # Excel file - requires readxl package
-ckanr_setup()
-res <- resource_show(id = "f4f871ae-139f-4acd-a700-8a08a1a04f95", as = "table")
+ckanr_setup('http://datamx.io')
+res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
 head(ckan_fetch(res$url))
 
 # XML file
-ckanr_setup("http://publicdata.eu/")
-res <- resource_show(id = "ba447d6b-271e-42c2-965e-945f8e26b2ff", as = "table")
+ckanr_setup("http://data.ottawa.ca")
+res <- resource_show(id = "380061c1-6c46-4da6-a01b-7ab0f49a881e", as = "table")
 ckan_fetch(res$url)
 
 # HTML file
-ckanr_setup("http://publicdata.eu/")
-res <- resource_show(id = "9b5bebd8-ff40-476c-beeb-aae172031d5f", as = "table")
+ckanr_setup("http://open.canada.ca/data/en")
+res <- resource_show(id = "80321bac-4283-487c-93bd-c65acaa660f5", as = "table")
 ckan_fetch(res$url)
 library("xml2")
-xml_text(xml_find_one(xml_children(ckan_fetch(res$url))[[1]], "title"))
+xml_text(xml_find_first(xml_children(ckan_fetch(res$url))[[1]], "title"))
 
 # JSON file, by default reads in to a data.frame for ease of use
-ckanr_setup("http://publicdata.eu/")
-res <- resource_show(id = "fa268f29-5e19-4402-a014-3e0fb93936a8", as = "table")
+ckanr_setup("http://data.surrey.ca")
+res <- resource_show(id = "8d07c662-800d-4977-9e3e-5a3d2d1e99ab", as = "table")
 head(ckan_fetch(res$url))
 
 # SHP file (spatial data, ESRI format)
-ckanr_setup("http://publicdata.eu/")
-res <- resource_show(id = "7618b8e2-7308-4964-8024-f13df166e7fd", as = "table")
+ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
+res <- resource_show(id = "6cbb0aa3-a8d1-421c-9c40-14c6f05e0c73", as = "table")
 x <- ckan_fetch(res$url)
 class(x)
 plot(x)


### PR DESCRIPTION
A few changes to the functionality of `ckan_fetch()` and the functions it depends on:
* Uses `sf::st_read()` instead of the deprecated`maptools::readShapePoints()`, closes #114 
* Updated examples in `ckan_fetch()` due to `http://publicdata.eu/` moving -- have changed them to some very 🇨🇦 centric ones!
* Allows reading and parsings of `xlsx` files (in addition to `xls` files already supported)
* (Some whitespace changes that just happen as a result of saving the file in RStudio -- not nitpicking your spaces!)

for the `xlsx` change, e.g. `ckan_fetch()` would return nothing with the current version of`ckanr` but works fine with the PR'd version:

``` r
library(ckanr)
#> Loading required package: DBI
ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")

res <- resource_show(id = "16772166-372d-422a-9bf0-a3d39c12d3a7", as = "table")

res$url
#> [1] "https://www.toronto.ca/ext/open_data/catalog/data_set_files/2017_Subway_Platform_Usage_Open_Data_Toronto.xlsx"

ckan_fetch(res$url)
#> New names:
#> * `` -> ...2
#> * `` -> ...3
#> * `` -> ...4
#> * `` -> ...5
#> * `` -> ...6
#> # A tibble: 79 x 6
#>    `Toronto Transit Commission`        ...2     ...3      ...4  ...5  ...6 
#>    <chr>                               <chr>    <chr>     <chr> <chr> <chr>
#>  1 Subway Station usage counts, 2017   <NA>     <NA>      <NA>  <NA>  <NA> 
#>  2 Showing number of customers travel… <NA>     <NA>      <NA>  <NA>  <NA> 
#>  3 <NA>                                <NA>     <NA>      <NA>  <NA>  <NA> 
#>  4 Rank, Total, of 74                  Station  Subway/R… To    From  Total
#>  5 1                                   BLOOR-Y… 1 Yonge-… 93924 1107… 2046…
#>  6 2                                   BLOOR-Y… 2 Bloor-… 96309 1001… 1964…
#>  7 3                                   UNION    1 Yonge-… 67881 60774 1286…
#>  8 4                                   ST. GEO… 1 Yonge-… 62131 64797 1269…
#>  9 5                                   ST. GEO… 2 Bloor-… 62668 62508 1251…
#> 10 6                                   FINCH    1 Yonge-… 43356 48707 92063
#> # … with 69 more rows
```
<sup>Created on 2019-06-26 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>

I didn't see any existing tests for `ckan_fetch()`, `read_session()`, or `fetch_GET()` but please let me know if I missed them!

Also, please let me know if I should update the codemeta to reflect the removal of `maptools` and addition of `sf` -- I think yes but wasn't 100% sure! I'll do so if needed.

Thanks!