### PR TITLE
Add optional format argument to ckan_fetch()

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -6,7 +6,7 @@
 #' @param store One of session (default) or disk. session stores in R session, and
 #' disk saves the file to disk.
 #' @param path if store=disk, you must give a path to store file to
-#' @param fmt Format of the file. Required if format is not detectable through file URL.
+#' @param format Format of the file. Required if format is not detectable through file URL.
 #' @param ... Curl arguments passed on to \code{\link[httr]{GET}}
 #' @examples \dontrun{
 #' # CSV file
@@ -19,7 +19,8 @@
 #' ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
 #' res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
 #' res$url
-#' head(ckan_fetch(res$url, fmt = "CSV"))
+#' res$format
+#' head(ckan_fetch(res$url, format = res$format))
 #'
 #' # Excel file - requires readxl package
 #' ckanr_setup("http://datamx.io")
@@ -50,15 +51,15 @@
 #' class(x)
 #' plot(x)
 #' }
-ckan_fetch <- function(x, store = "session", path = "file", fmt = NULL, ...) {
+ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) {
   store <- match.arg(store, c("session", "disk"))
   file_fmt <- file_fmt(x)
-  if (identical(file_fmt, character(0)) & is.null(fmt)){
+  if (identical(file_fmt, character(0)) & is.null(format)) {
     stop("File format is not available from URL; please specify via `format` argument.")
   }
-  fmt <- ifelse(identical(file_fmt, character(0)), fmt, file_fmt)
+  fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
   fmt <- tolower(fmt)
-  res <- fetch_GET(x, store, path, fmt = fmt, ...)
+  res <- fetch_GET(x, store, path, format = fmt, ...)
   if (store == "session") {
     read_session(res$fmt, res$data, res$path)
   } else {

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -6,6 +6,7 @@
 #' @param store One of session (default) or disk. session stores in R session, and
 #' disk saves the file to disk.
 #' @param path if store=disk, you must give a path to store file to
+#' @param format (optional) format of the file. One of "XSV", "XLS", "XLSX", "XML", "HTML", "JSON", "SHP". Case insensitive.
 #' @param ... Curl arguments passed on to \code{\link[httr]{GET}}
 #' @examples \dontrun{
 #' # CSV file
@@ -43,9 +44,15 @@
 #' class(x)
 #' plot(x)
 #' }
-ckan_fetch <- function(x, store = "session", path = "file", ...) {
+ckan_fetch <- function(x, store = "session", path = "file", fmt = NULL, ...) {
   store <- match.arg(store, c("session", "disk"))
-  res <- fetch_GET(x, store, path, ...)
+  file_fmt <- file_fmt(x)
+  if (identical(file_fmt, character(0)) & is.null(fmt)){
+    stop("File format is not available from URL; please specify via `format` argument.")
+  }
+  fmt <- ifelse(identical(file_fmt, character(0)), fmt, file_fmt)
+  fmt <- tolower(fmt)
+  res <- fetch_GET(x, store, path, fmt = fmt, ...)
   if (store == "session") {
     read_session(res$fmt, res$data, res$path)
   } else {

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -6,26 +6,32 @@
 #' @param store One of session (default) or disk. session stores in R session, and
 #' disk saves the file to disk.
 #' @param path if store=disk, you must give a path to store file to
-#' @param format (optional) format of the file. One of "XSV", "XLS", "XLSX", "XML", "HTML", "JSON", "SHP". Case insensitive.
+#' @param fmt Format of the file. Required if format is not detectable through file URL.
 #' @param ... Curl arguments passed on to \code{\link[httr]{GET}}
 #' @examples \dontrun{
 #' # CSV file
-#' ckanr_setup('http://datamx.io')
+#' ckanr_setup("http://datamx.io")
 #' res <- resource_show(id = "6145a539-cbde-4b0d-a3d3-d1a5eb013f5c", as = "table")
 #' head(ckan_fetch(res$url))
 #' ckan_fetch(res$url, "disk", "myfile.csv")
 #'
+#' # CSV file, format not available
+#' ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
+#' res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
+#' res$url
+#' head(ckan_fetch(res$url, fmt = "CSV"))
+#'
 #' # Excel file - requires readxl package
-#' ckanr_setup('http://datamx.io')
+#' ckanr_setup("http://datamx.io")
 #' res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
 #' head(ckan_fetch(res$url))
 #'
-#' # XML file
+#' # XML file - requires xml2 package
 #' ckanr_setup("http://data.ottawa.ca")
 #' res <- resource_show(id = "380061c1-6c46-4da6-a01b-7ab0f49a881e", as = "table")
 #' ckan_fetch(res$url)
 #'
-#' # HTML file
+#' # HTML file - requires xml2 package
 #' ckanr_setup("http://open.canada.ca/data/en")
 #' res <- resource_show(id = "80321bac-4283-487c-93bd-c65acaa660f5", as = "table")
 #' ckan_fetch(res$url)
@@ -37,7 +43,7 @@
 #' res <- resource_show(id = "8d07c662-800d-4977-9e3e-5a3d2d1e99ab", as = "table")
 #' head(ckan_fetch(res$url))
 #'
-#' # SHP file (spatial data, ESRI format)
+#' # SHP file (spatial data, ESRI format) - requires sf package
 #' ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
 #' res <- resource_show(id = "6cbb0aa3-a8d1-421c-9c40-14c6f05e0c73", as = "table")
 #' x <- ckan_fetch(res$url)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -54,7 +54,7 @@ ckan_VERB <- function(verb, url, method, body, key, ...) {
 }
 
 # GET fxn for fetch()
-fetch_GET <- function(x, store, path, args = NULL, fmt = NULL, ...) {
+fetch_GET <- function(x, store, path, args = NULL, format = NULL, ...) {
   # check if proxy set
   proxy <- get("ckanr_proxy", ckanr_settings_env)
   if (!is.null(proxy)) {
@@ -64,7 +64,7 @@ fetch_GET <- function(x, store, path, args = NULL, fmt = NULL, ...) {
   }
   # set file format
   file_fmt <- file_fmt(x)
-  fmt <- ifelse(identical(file_fmt, character(0)), fmt, file_fmt)
+  fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
   fmt <- tolower(fmt)
   if (store == "session") {
     if (fmt %in% c("xls", "xlsx")) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -54,7 +54,7 @@ ckan_VERB <- function(verb, url, method, body, key, ...) {
 }
 
 # GET fxn for fetch()
-fetch_GET <- function(x, store, path, args = NULL, ...) {
+fetch_GET <- function(x, store, path, args = NULL, fmt = NULL, ...) {
   # check if proxy set
   proxy <- get("ckanr_proxy", ckanr_settings_env)
   if (!is.null(proxy)) {
@@ -62,14 +62,17 @@ fetch_GET <- function(x, store, path, args = NULL, ...) {
       stop("proxy must be of class 'request', see ?ckanr_setup")
     }
   }
+  # set file format
+  file_fmt <- file_fmt(x)
+  fmt <- ifelse(identical(file_fmt, character(0)), fmt, file_fmt)
+  fmt <- tolower(fmt)
   if (store == "session") {
-    if (file_fmt(x) %in% c("xls", "xlsx")) {
-      fmt <- file_fmt(x)
+    if (fmt %in% c("xls", "xlsx")) {
       dat <- NULL
       path <- paste0(path, ".", fmt)
       res <- GET(x, query = args, write_disk(path, TRUE), config = proxy, ...)
       path <- res$request$output$path
-    } else if (file_fmt(x) %in% c("shp", "zip")) {
+    } else if (fmt %in% c("shp", "zip")) {
       fmt <- "shp"
       dat <- NULL
       path <- paste0(path, ".zip")
@@ -78,7 +81,6 @@ fetch_GET <- function(x, store, path, args = NULL, ...) {
       unzip(path, exdir = dir)
       path <- list.files(dir, pattern = ".shp$", full.names = TRUE)
     } else {
-      fmt <- file_fmt(x)
       path <- NULL
       res <- GET(x, query = args, config = proxy, ...)
       err_handler(res)
@@ -88,7 +90,7 @@ fetch_GET <- function(x, store, path, args = NULL, ...) {
   } else {
     # if (!file.exists(path)) stop("path does not exist", call. = FALSE)
     res <- GET(x, query = args, write_disk(path, TRUE), config = proxy, ...)
-    list(store = store, fmt = file_fmt(x), data = NULL, path = res$request$output$path)
+    list(store = store, fmt = fmt, data = NULL, path = res$request$output$path)
   }
 }
 

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -4,7 +4,7 @@
 \alias{ckan_fetch}
 \title{Download a file}
 \usage{
-ckan_fetch(x, store = "session", path = "file", format = NULL, ...)
+ckan_fetch(x, store = "session", path = "file", fmt = NULL, ...)
 }
 \arguments{
 \item{x}{URL for the file}
@@ -14,7 +14,7 @@ disk saves the file to disk.}
 
 \item{path}{if store=disk, you must give a path to store file to}
 
-\item{format}{(optional) format of the file. One of "XSV", "XLS", "XLSX", "XML", "HTML", "JSON", "SHP". Case insensitive.}
+\item{fmt}{Format of the file. Required if format is not detectable through file URL.}
 
 \item{...}{Curl arguments passed on to \code{\link[httr]{GET}}}
 }
@@ -24,22 +24,28 @@ Download a file
 \examples{
 \dontrun{
 # CSV file
-ckanr_setup('http://datamx.io')
+ckanr_setup("http://datamx.io")
 res <- resource_show(id = "6145a539-cbde-4b0d-a3d3-d1a5eb013f5c", as = "table")
 head(ckan_fetch(res$url))
 ckan_fetch(res$url, "disk", "myfile.csv")
 
+# CSV file, format not available
+ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
+res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
+res$url
+head(ckan_fetch(res$url, fmt = "CSV"))
+
 # Excel file - requires readxl package
-ckanr_setup('http://datamx.io')
+ckanr_setup("http://datamx.io")
 res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
 head(ckan_fetch(res$url))
 
-# XML file
+# XML file - requires xml2 package
 ckanr_setup("http://data.ottawa.ca")
 res <- resource_show(id = "380061c1-6c46-4da6-a01b-7ab0f49a881e", as = "table")
 ckan_fetch(res$url)
 
-# HTML file
+# HTML file - requires xml2 package
 ckanr_setup("http://open.canada.ca/data/en")
 res <- resource_show(id = "80321bac-4283-487c-93bd-c65acaa660f5", as = "table")
 ckan_fetch(res$url)
@@ -51,7 +57,7 @@ ckanr_setup("http://data.surrey.ca")
 res <- resource_show(id = "8d07c662-800d-4977-9e3e-5a3d2d1e99ab", as = "table")
 head(ckan_fetch(res$url))
 
-# SHP file (spatial data, ESRI format)
+# SHP file (spatial data, ESRI format) - requires sf package
 ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
 res <- resource_show(id = "6cbb0aa3-a8d1-421c-9c40-14c6f05e0c73", as = "table")
 x <- ckan_fetch(res$url)

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -4,7 +4,7 @@
 \alias{ckan_fetch}
 \title{Download a file}
 \usage{
-ckan_fetch(x, store = "session", path = "file", fmt = NULL, ...)
+ckan_fetch(x, store = "session", path = "file", format = NULL, ...)
 }
 \arguments{
 \item{x}{URL for the file}
@@ -14,7 +14,7 @@ disk saves the file to disk.}
 
 \item{path}{if store=disk, you must give a path to store file to}
 
-\item{fmt}{Format of the file. Required if format is not detectable through file URL.}
+\item{format}{Format of the file. Required if format is not detectable through file URL.}
 
 \item{...}{Curl arguments passed on to \code{\link[httr]{GET}}}
 }
@@ -33,7 +33,8 @@ ckan_fetch(res$url, "disk", "myfile.csv")
 ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
 res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
 res$url
-head(ckan_fetch(res$url, fmt = "CSV"))
+res$format
+head(ckan_fetch(res$url, fmt = res$format))
 
 # Excel file - requires readxl package
 ckanr_setup("http://datamx.io")

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -34,7 +34,7 @@ ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
 res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
 res$url
 res$format
-head(ckan_fetch(res$url, fmt = res$format))
+head(ckan_fetch(res$url, format = res$format))
 
 # Excel file - requires readxl package
 ckanr_setup("http://datamx.io")

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -4,7 +4,7 @@
 \alias{ckan_fetch}
 \title{Download a file}
 \usage{
-ckan_fetch(x, store = "session", path = "file", ...)
+ckan_fetch(x, store = "session", path = "file", format = NULL, ...)
 }
 \arguments{
 \item{x}{URL for the file}
@@ -13,6 +13,8 @@ ckan_fetch(x, store = "session", path = "file", ...)
 disk saves the file to disk.}
 
 \item{path}{if store=disk, you must give a path to store file to}
+
+\item{format}{(optional) format of the file. One of "XSV", "XLS", "XLSX", "XML", "HTML", "JSON", "SHP". Case insensitive.}
 
 \item{...}{Curl arguments passed on to \code{\link[httr]{GET}}}
 }


### PR DESCRIPTION
Adds an additional (optional) `format` parameter to `ckan_fetch()` so that downloading can succeed even if the resource URL doesn't have the format in its extension; closes #116. I also started a test file for `ckan_fetch()`, starting with ensuring that the error works as expected.

Some examples:
``` r
library(ckanr)
#> Loading required package: DBI

ckanr_setup("https://data.europa.eu/euodp/data/")
res <- resource_show(id = "f2cfb3f8-44f6-4027-952f-a1d759484501", as = "table")
ckan_fetch(res$url)
#> Error in ckan_fetch(res$url): File format is not available from URL; please specify via `format` argument.
ckan_fetch(res$url, format = res$format)
#> {xml_document}
#> <html lang="en" dir="ltr" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:dc="http://purl.org/dc/terms/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:og="http://ogp.me/ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:sioc="http://rdfs.org/sioc/ns#" xmlns:sioct="http://rdfs.org/sioc/types#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
#> [1] <head profile="http://www.w3.org/1999/xhtml/vocab">\n<meta charset=" ...
#> [2] <body class="html not-front not-logged-in one-sidebar sidebar-first  ...

ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
res <- resource_show(id = "75c69a49-8573-4dda-b41a-d312a33b2e05", as = "table")
head(ckan_fetch(res$url))
#> Error in ckan_fetch(res$url): File format is not available from URL; please specify via `format` argument.
head(ckan_fetch(res$url, format = res$format))
#>      X_id estStatusDesc enfrID inspID infrTypeCD postal rowNo
#> 1 2214143          Pass     NA  72246      10005    M1G     1
#> 2 2214144          Pass     NA  72246      10011    M1G     2
#> 3 2214145          Pass     NA  72246      10015    M1G     3
#> 4 2214146          Pass     NA  72247      10012    M1G     4
#> 5 2214147          Pass     NA  72247      10015    M1G     5
#> 6 2214148          Pass     NA  72248      10005    M1G     6
#>                  addr          estName       infrAction       lon servID
#> 1 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556681
#> 2 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556681
#> 3 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556681
#> 4 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556682
#> 5 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556682
#> 6 3770 LAWRENCE AVE E PINK NAILS & SPA Notice to Comply -79.21424 556681
#>   enfrOutcome unit
#> 1                 
#> 2                 
#> 3                 
#> 4                 
#> 5                 
#> 6                 
#>                                                                      infrTypeDesc
#> 1                                        Single-use items used on one client only
#> 2                  Semi-critical items maintained in a sanitary manner before use
#> 3                         Work surfaces cleaned then disinfected with a LLD daily
#> 4 Semi-critical items cleaned then disinfected with an ILD or HLD between clients
#> 5                         Work surfaces cleaned then disinfected with a LLD daily
#> 6                                        Single-use items used on one client only
#>   enfrAmountFined inspStatusDesc enfrOutcomeDate     lat servTypeCD
#> 1              NA    Conditional                 43.7625       7017
#> 2              NA    Conditional                 43.7625       7017
#> 3              NA    Conditional                 43.7625       7017
#> 4              NA    Conditional                 43.7625       7018
#> 5              NA    Conditional                 43.7625       7018
#> 6              NA    Conditional                 43.7625       7017
#>              inspDate infrID  addrID   estID servTypeDesc estStatusCD
#> 1 2016-11-09T00:00:00   8460 2907806 3644116        Nails        PASS
#> 2 2016-11-09T00:00:00   8461 2907806 3644116        Nails        PASS
#> 3 2016-11-09T00:00:00   8462 2907806 3644116        Nails        PASS
#> 4 2016-11-09T00:00:00   8463 2907806 3644116   Aesthetics        PASS
#> 5 2016-11-09T00:00:00   8464 2907806 3644116   Aesthetics        PASS
#> 6 2016-11-15T00:00:00   8465 2907806 3644116        Nails        PASS
```

<sup>Created on 2019-06-27 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>