### PR TITLE
Add test for ckan_fetch()

### DIFF
--- a/tests/testthat/test-ckan_fetch.R
+++ b/tests/testthat/test-ckan_fetch.R
@@ -1,0 +1,8 @@
+context("ckan_fetch")
+
+test_that("ckan_fetch returns error when file format can't be determined from URL", {
+  expect_error(
+    ckan_fetch("https://ckan0.cf.opendata.inter.sandbox-toronto.ca/datastore/dump/75c69a49-8573-4dda-b41a-d312a33b2e05"),
+    "File format is not available from URL; please specify via `format` argument."
+  )
+})


### PR DESCRIPTION
Add a test for the changes in #117, ensuring that the error works as expected when the format can't be parsed from the URL.