### PR TITLE
fix: #122 include key during call to package_show

### DIFF
--- a/R/as-ckan_package.R
+++ b/R/as-ckan_package.R
@@ -51,7 +51,7 @@ sift_res <- function(z) {
   }
 }
 
-get_package <- function(id, url = get_default_url(), ...) {
-  res <- ckan_GET(url, 'package_show', list(id = id), NULL, ...)
+get_package <- function(id, url = get_default_url(), key = get_default_key(), ...) {
+  res <- ckan_GET(url, 'package_show', list(id = id), key, ...)
   as_ck(jsl(res), "ckan_package")
 }


### PR DESCRIPTION
Include API Key During Call to Package Show (resolves #122)

## Description
<!--- Describe your changes in detail -->

I updated the `get_package` call to explicitly pass along the API Key using `get_default_key`.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
fix #122

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
