### PR TITLE
Include traceback in standard issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,8 +1,18 @@
-<!-- If this issue relates to usage of the package, whether a question, bug or similar, along with your query, please paste your devtools::session_info() or sessionInfo() into the code block below. If not, delete all this and proceed :) -->
+<!-- If this issue relates to usage of the package, whether a question, bug or similar, along with your query, please paste your devtools::session_info() or sessionInfo() into the code block below. If ckanr threw an error, please also post the traceback() of the error. Otherwise, delete all this and proceed :) -->
 
-<details> <summary><strong>Session Info</strong></summary>
+<details>
+<summary><strong>Session Info and Traceback</strong></summary>
 
+<!-- SessionInfo captures the exact circumstances under which the error happened: OS, installed packages. -->
 ```r
+# devtools::session_info()  # or
+utils::sessionInfo()
+
+```
+
+<!-- If ckanr threw an error, run traceback() immediately after the error and paste the results here. -->
+```r
+traceback()
 
 ```
 </details>


### PR DESCRIPTION
Minor update to the standard issue template. In the long run, should `ckanr` use separate issue templates as per https://help.github.com/en/articles/about-issue-and-pull-request-templates? Happy to send PR.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Included a code block for the `traceback()` and explanatory comments to the details section.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->
@sckott had to remind me of the traceback() in #122 - let's push that onus to the issue template. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
Minor change, no code touched, no tests added.