### PR TITLE
Update ckan_fetch() to handle non-SHP zip files

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -75,16 +75,15 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) 
   fmt <- tolower(fmt)
   res <- fetch_GET(x, store, path, format = fmt, ...)
   if (store == "session") {
-    if(res$fmt == "zip") {
+    if (res$fmt == "zip") {
       temp_res <- vector(mode = "list", length = length(res$path))
-      for(i in seq_along(res$path)) {
+      for (i in seq_along(res$path)) {
         temp_res[[i]] <- read_session(file_fmt(res$path[[i]]), res$data, res$path[[i]])
       }
       temp_names <- res$path
       temp_names <- gsub(paste0(tempdir(), "/"), "", temp_names)
       names(temp_res) <- temp_names
-    }
-    else{
+    } else {
       temp_res <- read_session(res$fmt, res$data, res$path)
     }
     unlink(res$temp_files)
@@ -97,10 +96,9 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) 
 read_session <- function(fmt, dat, path) {
   switch(fmt,
          csv = {
-           if(!is.null(dat)) {
+           if (!is.null(dat)) {
              read.csv(text = dat, fileEncoding = "latin1")
-             }
-           else {
+           } else {
              read.csv(path, fileEncoding = "latin1")
            }
          },

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -58,6 +58,12 @@
 #' class(x)
 #' plot(x[, c("mun_name", "geometry")])
 #'
+#' # ZIP file - packages required depends on contents
+#' ckanr_setup("https://ckan0.cf.opendata.inter.sandbox-toronto.ca")
+#' res <- resource_show(id = "56738509-8612-404c-96e3-27c175321aa7", as = "table")
+#' x <- ckan_fetch(res$url)
+#' names(x)
+#' head(x[["ChickenpoxAgegroups2017.csv"]])
 #' }
 ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) {
   store <- match.arg(store, c("session", "disk"))

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -75,9 +75,9 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) 
   fmt <- tolower(fmt)
   res <- fetch_GET(x, store, path, format = fmt, ...)
   if (store == "session") {
-    if(res$fmt == "zip"){
+    if(res$fmt == "zip") {
       temp_res <- vector(mode = "list", length = length(res$path))
-      for(i in seq_along(res$path)){
+      for(i in seq_along(res$path)) {
         temp_res[[i]] <- read_session(file_fmt(res$path[[i]]), res$data, res$path[[i]])
       }
       temp_names <- res$path

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -74,7 +74,6 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, ...) {
       path <- res$request$output$path
       temp_files <- path
     } else if (fmt %in% c("shp", "zip")) {
-      fmt <- "shp"
       dat <- NULL
       path <- tempfile(fileext = ".zip")
       res <- GET(x, query = args, write_disk(path, TRUE), config = proxy, ...)
@@ -84,6 +83,13 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, ...) {
       unzip(path, exdir = dir)
       temp_files <- c(path, zip_files)
       path <- list.files(dir, pattern = ".shp$", full.names = TRUE)
+      if(identical(path, character(0))){
+        fmt <- "zip"
+        path <- zip_files
+      }
+      else{
+        fmt <- "shp"
+      }
     } else {
       path <- NULL
       temp_files <- NULL

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -83,11 +83,10 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, ...) {
       unzip(path, exdir = dir)
       temp_files <- c(path, zip_files)
       path <- list.files(dir, pattern = ".shp$", full.names = TRUE)
-      if(identical(path, character(0))) {
+      if (identical(path, character(0))) {
         fmt <- "zip"
         path <- zip_files
-      }
-      else {
+      } else {
         fmt <- "shp"
       }
     } else {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -83,11 +83,11 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, ...) {
       unzip(path, exdir = dir)
       temp_files <- c(path, zip_files)
       path <- list.files(dir, pattern = ".shp$", full.names = TRUE)
-      if(identical(path, character(0))){
+      if(identical(path, character(0))) {
         fmt <- "zip"
         path <- zip_files
       }
-      else{
+      else {
         fmt <- "shp"
       }
     } else {


### PR DESCRIPTION
The current treatment of `zip` files in `ckan_fetch()` only handles if they contain`shp` files, but it's possible for resources to have a zip files of other, non-shp files, that would need to be read in (the example added is [this](https://portal0.cf.opendata.inter.sandbox-toronto.ca/dataset/annual-summary-of-reportable-communicable-diseases/)). 

This PR checks if, unzipped, the resource contains `shp` files -- if so, the current method is used. If not, then it reads each file in separately and returns the result in a list, where the name is the name of the file in the zip.

The change to the `read.csv()` encoding is because i specifically ran into a file where it was an issue; let me know if you would prefer this in a different PR (or if there's a different encoding approach i should use). thanks!