### PR TITLE
Add API key header to ckan_fetch

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -68,7 +68,7 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, key =
   }
   fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
   fmt <- tolower(fmt)
-  res <- fetch_GET(x, store, path, format = fmt, key = get_default_key(), ...)
+  res <- fetch_GET(x, store, path, format = fmt, key = key, ...)
   if (store == "session") {
     temp_res <- read_session(res$fmt, res$data, res$path)
     unlink(res$temp_files)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -7,6 +7,7 @@
 #' disk saves the file to disk.
 #' @param path if store=disk, you must give a path to store file to
 #' @param format Format of the file. Required if format is not detectable through file URL.
+#' @param key A CKAN API key (optional, character)
 #' @param ... Curl arguments passed on to \code{\link[httr]{GET}}
 #' @examples \dontrun{
 #' # CSV file
@@ -59,7 +60,7 @@
 #' plot(x[, c("mun_name", "geometry")])
 #'
 #' }
-ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) {
+ckan_fetch <- function(x, store = "session", path = "file", format = NULL, key = get_default_key(), ...) {
   store <- match.arg(store, c("session", "disk"))
   file_fmt <- file_fmt(x)
   if (identical(file_fmt, character(0)) & is.null(format)) {
@@ -67,7 +68,7 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, ...) 
   }
   fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
   fmt <- tolower(fmt)
-  res <- fetch_GET(x, store, path, format = fmt, ...)
+  res <- fetch_GET(x, store, path, format = fmt, key = get_default_key(), ...)
   if (store == "session") {
     temp_res <- read_session(res$fmt, res$data, res$path)
     unlink(res$temp_files)

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -4,7 +4,8 @@
 \alias{ckan_fetch}
 \title{Download a file}
 \usage{
-ckan_fetch(x, store = "session", path = "file", format = NULL, ...)
+ckan_fetch(x, store = "session", path = "file", format = NULL,
+  key = get_default_key(), ...)
 }
 \arguments{
 \item{x}{URL for the file}
@@ -15,6 +16,8 @@ disk saves the file to disk.}
 \item{path}{if store=disk, you must give a path to store file to}
 
 \item{format}{Format of the file. Required if format is not detectable through file URL.}
+
+\item{key}{A CKAN API key (optional, character)}
 
 \item{...}{Curl arguments passed on to \code{\link[httr]{GET}}}
 }


### PR DESCRIPTION
I think this is what's needed to add the API key header to `ckan_fetch()` as in @jonocarroll's comment in #122. I don't have access to a CKAN instance that needs an API key, so let me know if i'm off. thanks!