### PR TITLE
Parse CKAN version number including patch/dev versions

### DIFF
--- a/R/ckan_info.R
+++ b/R/ckan_info.R
@@ -23,10 +23,17 @@ ckan_info <- function(url = get_default_url(), ...) {
 #' @rdname ckan_info
 ckan_version <- function(url, ...) {
   ver <- ckan_info(url, ...)$ckan_version
-  nn <- as.numeric(
-    paste0(
-      unlist(regmatches(ver, gregexpr("[[:digit:]]+", ver))),
-      collapse = "")
-  )
+  nn <- parse_version_number(ver)
   list(version = ver, version_num = nn)
+}
+
+parse_version_number <- function(x) {
+  version_components <- unlist(regmatches(x, gregexpr("[[:digit:]]+", x)))
+  major_minor <- paste0(version_components[1:2], collapse = "")
+  if (length(version_components) == 2) {
+    as.numeric(major_minor)
+  } else {
+    patch_etc <- paste0(version_components[-c(1:2)], collapse = "")
+    as.numeric(paste0(major_minor, ".", patch_etc))
+  }
 }

--- a/R/ckan_info.R
+++ b/R/ckan_info.R
@@ -21,7 +21,7 @@ ckan_info <- function(url = get_default_url(), ...) {
 #' @param url Base url to use. Default: \url{http://data.techno-science.ca}. See
 #' also \code{\link{ckanr_setup}} and \code{\link{get_default_url}}. (required)
 #' @rdname ckan_info
-ckan_version <- function(url, ...) {
+ckan_version <- function(url = get_default_url(), ...) {
   ver <- ckan_info(url, ...)$ckan_version
   nn <- parse_version_number(ver)
   list(version = ver, version_num = nn)

--- a/man/ckan_info.Rd
+++ b/man/ckan_info.Rd
@@ -7,7 +7,7 @@
 \usage{
 ckan_info(url = get_default_url(), ...)
 
-ckan_version(url, ...)
+ckan_version(url = get_default_url(), ...)
 }
 \arguments{
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See

--- a/tests/testthat/test-ckan_info.R
+++ b/tests/testthat/test-ckan_info.R
@@ -2,7 +2,9 @@ context("test-ckan_info")
 
 test_that("parse_version_number parses correctly.", {
   expect_equal(parse_version_number("2.1"), 21)
+  expect_equal(parse_version_number("2.1b"), 21)
   expect_equal(parse_version_number("2.1.0"), 21)
+  expect_equal(parse_version_number("2.1.1b"), 21.1)
   expect_equal(parse_version_number("2.1.1"), 21.1)
   expect_equal(parse_version_number("21.1.1"), 211.1)
   expect_equal(parse_version_number("0.0.1"), 0.1)

--- a/tests/testthat/test-ckan_info.R
+++ b/tests/testthat/test-ckan_info.R
@@ -1,0 +1,12 @@
+context("test-ckan_info")
+
+test_that("parse_version_number parses correctly.", {
+  expect_equal(parse_version_number("2.1"), 21)
+  expect_equal(parse_version_number("2.1.0"), 21)
+  expect_equal(parse_version_number("2.1.1"), 21.1)
+  expect_equal(parse_version_number("21.1.1"), 211.1)
+  expect_equal(parse_version_number("0.0.1"), 0.1)
+  expect_equal(parse_version_number("0.1.1"), 1.1)
+  expect_equal(parse_version_number("0.1.0"), 1)
+  expect_equal(parse_version_number("0.0.0.9000"), 0.09)
+})


### PR DESCRIPTION
The current implementation of `ckan_version()` doesn't properly handle patch or dev versions, e.g. `2.2.1` gets converted to `221` instead of e.g. `22.1`, which causes issues downstream (i.e., in `package_search()`).

This implementation parses patch and dev versions too, e.g. `2.1.1` becomes `21.1`, `2.1` is `21`, `2.1.0` is `21`, etc.

Also added tests and set the default value of `url` to `get_default_url()` (that's what the documentation states it is, but it looks like it may have been missed). thanks!