### PR TITLE
Change default_schema and include_private parameter availability logic in package_search

### DIFF
--- a/R/package_search.R
+++ b/R/package_search.R
@@ -28,12 +28,12 @@
 #' @param include_drafts (logical) if \code{TRUE} draft datasets will be 
 #' included. A user will only be returned their own draft datasets, and a 
 #' sysadmin will be returned all draft datasets. default: \code{FALSE}.
-#' first CKAN version: 2.4.9; dropped from request if CKAN version is older
+#' first CKAN version: 2.6.1; dropped from request if CKAN version is older
 #' @param include_private (logical) if \code{TRUE} private datasets will be 
 #' included. Only private datasets from the user’s organizations will be 
 #' returned and sysadmins will be returned all private datasets.
 #' default: \code{FALSE}
-#' first CKAN version: 2.6; dropped from request if CKAN version is older
+#' first CKAN version: 2.6.1; dropped from request if CKAN version is older
 #' @param use_default_schema (logical) use default package schema instead of a
 #' custom schema defined with an IDatasetForm plugin. default: \code{FALSE}
 #' first CKAN version: 2.3.5; dropped from request if CKAN version is older
@@ -66,11 +66,11 @@ package_search <- function(q = '*:*', fq = NULL, sort = NULL, rows = NULL,
     include_private = as_log(include_private), 
     use_default_schema = as_log(use_default_schema)
   ))
-  if (ver <= 23) {
-    args$use_default_schema <- args$include_drafts <- args$include_private <- NULL
+  if (ver < 23.5) {
+    args$include_drafts <- args$use_default_schema <- args$include_private <- NULL
+  } else if (ver < 26.1) {
+    args$use_default_schema <- args$include_private <- NULL
   }
-  if (ver < 24) args$include_drafts <- args$include_private <- NULL
-  if (ver < 26) args$include_private <- NULL
   res <- ckan_GET(url, 'package_search', args, key = key, ...)
   switch(as, json = res,
          list = {

--- a/man/package_search.Rd
+++ b/man/package_search.Rd
@@ -46,13 +46,13 @@ be included in the results}
 \item{include_drafts}{(logical) if \code{TRUE} draft datasets will be 
 included. A user will only be returned their own draft datasets, and a 
 sysadmin will be returned all draft datasets. default: \code{FALSE}.
-first CKAN version: 2.4.9; dropped from request if CKAN version is older}
+first CKAN version: 2.6.1; dropped from request if CKAN version is older}
 
 \item{include_private}{(logical) if \code{TRUE} private datasets will be 
 included. Only private datasets from the user’s organizations will be 
 returned and sysadmins will be returned all private datasets.
 default: \code{FALSE}
-first CKAN version: 2.6; dropped from request if CKAN version is older}
+first CKAN version: 2.6.1; dropped from request if CKAN version is older}
 
 \item{use_default_schema}{(logical) use default package schema instead of a
 custom schema defined with an IDatasetForm plugin. default: \code{FALSE}


### PR DESCRIPTION
as i said in #136, it looks like the ckan version logic used in `package_search()` is a little off. using the version of code in that PR:

``` r
library(ckanr)

ckan_version("http://data.techno-science.ca/")
#> $version
#> [1] "2.2"
#> 
#> $version_num
#> [1] 22
package_search(url = "http://data.techno-science.ca/", rows = 0)
#> $count
#> [1] 36
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://datamx.io")
#> $version
#> [1] "2.2.1b"
#> 
#> $version_num
#> [1] 22.1
package_search(url = "http://datamx.io", rows = 0)
#> $count
#> [1] 9659
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://data.ottawa.ca")
#> $version
#> [1] "2.4a"
#> 
#> $version_num
#> [1] 24
package_search(url = "http://data.ottawa.ca", rows = 0)
#> Error: 400 - Search Query Error
#>   message Search Query is invalid: "Invalid search parameters: ['use_default_schema']"

ckan_version("http://data.surrey.ca")
#> $version
#> [1] "2.4.2"
#> 
#> $version_num
#> [1] 24.2
package_search(url = "http://data.surrey.ca", rows = 0)
#> Error: 400 - Search Query Error
#>   message Search Query is invalid: "Invalid search parameters: ['use_default_schema']"

ckan_version("http://opendata.aachen.de")
#> $version
#> [1] "2.6.0a"
#> 
#> $version_num
#> [1] 26
package_search(url = "http://opendata.aachen.de", rows = 0)
#> Error: 400 - Search Query Error
#>   message Search Query is invalid: "Invalid search parameters: ['use_default_schema', 'include_private']"

ckan_version("http://opendata.awt.be") 
#> $version
#> [1] "2.6.1"
#> 
#> $version_num
#> [1] 26.1
package_search(url = "http://opendata.awt.be", rows = 0)
#> $count
#> [1] 423
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()
```

using the version in this PR (plus the changes to the `ckan_version()`, sorry, i realize testing it is a little convoluted)

``` r
library(ckanr)

ckan_version("http://data.techno-science.ca/")
#> $version
#> [1] "2.2"
#> 
#> $version_num
#> [1] 22
package_search(url = "http://data.techno-science.ca/", rows = 0)
#> $count
#> [1] 36
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://datamx.io")
#> $version
#> [1] "2.2.1b"
#> 
#> $version_num
#> [1] 22.1
package_search(url = "http://datamx.io", rows = 0)
#> $count
#> [1] 9659
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://data.ottawa.ca")
#> $version
#> [1] "2.4a"
#> 
#> $version_num
#> [1] 24
package_search(url = "http://data.ottawa.ca", rows = 0)
#> $count
#> [1] 187
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://data.surrey.ca")
#> $version
#> [1] "2.4.2"
#> 
#> $version_num
#> [1] 24.2
package_search(url = "http://data.surrey.ca", rows = 0)
#> $count
#> [1] 366
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://opendata.aachen.de")
#> $version
#> [1] "2.6.0a"
#> 
#> $version_num
#> [1] 26
package_search(url = "http://opendata.aachen.de", rows = 0)
#> $count
#> [1] 77
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()

ckan_version("http://opendata.awt.be") 
#> $version
#> [1] "2.6.1"
#> 
#> $version_num
#> [1] 26.1
package_search(url = "http://opendata.awt.be", rows = 0)
#> $count
#> [1] 423
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()
```

<sup>Created on 2019-08-05 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>