### PR TITLE
Handle case where CKAN version isn't available

### DIFF
--- a/man/package_search.Rd
+++ b/man/package_search.Rd
@@ -46,17 +46,20 @@ be included in the results}
 \item{include_drafts}{(logical) if \code{TRUE} draft datasets will be 
 included. A user will only be returned their own draft datasets, and a 
 sysadmin will be returned all draft datasets. default: \code{FALSE}.
-first CKAN version: 2.6.1; dropped from request if CKAN version is older}
+first CKAN version: 2.6.1; dropped from request if CKAN version is older
+or if CKAN version isn't available via \code{\link{ckan_version}}}
 
 \item{include_private}{(logical) if \code{TRUE} private datasets will be 
 included. Only private datasets from the user’s organizations will be 
 returned and sysadmins will be returned all private datasets.
 default: \code{FALSE}
-first CKAN version: 2.6.1; dropped from request if CKAN version is older}
+first CKAN version: 2.6.1; dropped from request if CKAN version is older
+or if CKAN version isn't available via \code{\link{ckan_version}}}
 
 \item{use_default_schema}{(logical) use default package schema instead of a
 custom schema defined with an IDatasetForm plugin. default: \code{FALSE}
-first CKAN version: 2.3.5; dropped from request if CKAN version is older}
+first CKAN version: 2.3.5; dropped from request if CKAN version is older
+or if CKAN version isn't available via \code{\link{ckan_version}}}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{ckanr_setup}} and \code{\link{get_default_url}}.}


### PR DESCRIPTION
Sometimes the CKAN version isn't available via `api/util/status` so `package_search()` currently fails:

``` r
library(ckanr)

package_search(url = "http://data.go.id")
#> Error in ckan_info(url, ...): Not Found (HTTP 404).
package_search(url = "http://data.london.gov.uk")
#> Error in ckan_info(url, ...): Not Found (HTTP 404).
package_search(url = "https://ckan0.cf.opendata.inter.prod-toronto.ca")
#> Error in ckan_info(url, ...): Forbidden (HTTP 403).
```

the implementation in this PR treats the version as unknown (and therefore maybe < 2.3.5) so sets `include_drafts`, `use_default_schema`, and `include_private` as `NULL` so the functions doesn't fail (because we don't know if those params are available):

``` r
library(ckanr)
#> Loading required package: DBI

package_search(url = "http://data.go.id", rows = 0)
#> $count
#> [1] 79168
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()
package_search(url = "http://data.london.gov.uk", rows = 0)
#> $count
#> [1] 837
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $search_facets
#> named list()
#> 
#> $facets
#> named list()
#> 
#> $result
#> list()
#> 
#> $spelling
#> NULL
#> 
#> $results
#> list()
package_search(url = "https://ckan0.cf.opendata.inter.prod-toronto.ca", rows = 0)
#> $count
#> [1] 308
#> 
#> $sort
#> [1] "score desc, metadata_modified desc"
#> 
#> $facets
#> named list()
#> 
#> $results
#> list()
#> 
#> $search_facets
#> named list()
```

lmk your thoughts on this. i don't know if using `try()` is the best way to catch whether `ckan_version()` fails or it'd be better to have `ckan_version()` actually return `NA` if it's not available (instead of failing). thanks! i think this is my last PR for a bit 😁 