### PR TITLE
Use basename() for filenames

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -89,7 +89,7 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL, key =
         temp_res[[i]] <- read_session(file_fmt(res$path[[i]]), res$data, res$path[[i]])
       }
       temp_names <- res$path
-      temp_names <- gsub(paste0(tempdir(), "/"), "", temp_names)
+      temp_names <- basename(temp_names)
       names(temp_res) <- temp_names
     } else {
       temp_res <- read_session(res$fmt, res$data, res$path)


### PR DESCRIPTION
Using `basename()` to get the file names for ZIP resources is way more robust than `gsub(paste0(tempdir(` etc, i.e. it actually works on Windows.

compare master

``` r
library(ckanr)
ckanr_setup("https://ckan0.cf.opendata.inter.prod-toronto.ca")
res <- resource_show(id = "bb21e1b8-a466-41c6-8bc3-3c362cb1ed55", as = "table")
x <- ckan_fetch(res$url)
names(x)
#> [1] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/ChickenpoxAgegroups2017.csv"             
#> [2] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/DiseaseSexandAgegroups2017.csv"          
#> [3] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/MeansbyDiseaseSex2007_2016.csv"          
#> [4] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/RatesbyDisease2007_2017.csv"             
#> [5] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/RatesbyDiseaseandSex2007_2017.csv"       
#> [6] "C:\\Users\\shg\\AppData\\Local\\Temp\\RtmpQpCyuY/read me file for annual report data.xlsx"
```

vs this branch

``` r
library(ckanr)
ckanr_setup("https://ckan0.cf.opendata.inter.prod-toronto.ca")
res <- resource_show(id = "bb21e1b8-a466-41c6-8bc3-3c362cb1ed55", as = "table")
x <- ckan_fetch(res$url)
names(x)
#> [1] "ChickenpoxAgegroups2017.csv"             
#> [2] "DiseaseSexandAgegroups2017.csv"          
#> [3] "MeansbyDiseaseSex2007_2016.csv"          
#> [4] "RatesbyDisease2007_2017.csv"             
#> [5] "RatesbyDiseaseandSex2007_2017.csv"       
#> [6] "read me file for annual report data.xlsx"
```
