### PR TITLE
Minor fixes for private datasets

### DIFF
--- a/R/package_create.R
+++ b/R/package_create.R
@@ -5,6 +5,8 @@
 #' @param name (character) the name of the new dataset, must be between 2 and 100 characters
 #' long and contain only lowercase alphanumeric characters, - and _, e.g. 'warandpeace'
 #' @param title (character) the title of the dataset (optional, default: same as name)
+#' @param private (logical) whether or not the dataset should be private
+#' (optional, default: FALSE).
 #' @param author (character) the name of the dataset's author (optional)
 #' @param author_email (character) the email address of the dataset's author (optional)
 #' @param maintainer (character) the name of the dataset's maintainer (optional)
@@ -54,13 +56,13 @@
 #' (res <- package_create("helloworld", author="Jane DOe"))
 #'
 #' }
-package_create <- function(name = NULL, title = NULL, author = NULL, author_email = NULL,
+package_create <- function(name = NULL, title = NULL, private=FALSE, author = NULL, author_email = NULL,
   maintainer = NULL, maintainer_email = NULL, license_id = NULL, notes = NULL, package_url = NULL,
   version = NULL, state = "active", type = NULL, resources = NULL, tags = NULL, extras = NULL,
   relationships_as_object = NULL, relationships_as_subject = NULL, groups = NULL,
   owner_org = NULL, url = get_default_url(), key = get_default_key(), as = 'list', ...) {
 
-  body <- cc(list(name = name, title = title, author = author, author_email = author_email,
+  body <- cc(list(name = name, title = title, private = private, author = author, author_email = author_email,
     maintainer = maintainer, maintainer_email = maintainer_email, license_id = license_id,
     notes = notes, url = package_url, version = version, state = state, type = type,
     resources = resources, tags = tags, extras = extras,

--- a/R/package_create.R
+++ b/R/package_create.R
@@ -5,8 +5,8 @@
 #' @param name (character) the name of the new dataset, must be between 2 and 100 characters
 #' long and contain only lowercase alphanumeric characters, - and _, e.g. 'warandpeace'
 #' @param title (character) the title of the dataset (optional, default: same as name)
-#' @param private (logical) whether or not the dataset should be private
-#' (optional, default: FALSE).
+#' @param private (logical) whether the dataset should be private (optional,
+#' default: FALSE), requires a value for \code{owner_org} if TRUE
 #' @param author (character) the name of the dataset's author (optional)
 #' @param author_email (character) the email address of the dataset's author (optional)
 #' @param maintainer (character) the name of the dataset's maintainer (optional)

--- a/R/package_patch.R
+++ b/R/package_patch.R
@@ -18,7 +18,7 @@
 #' }
 package_patch <- function(x, id, key = get_default_key(),
                            url = get_default_url(), as = 'list', ...) {
-  id <- as.ckan_package(id, url = url)
+  id <- as.ckan_package(id, url = url, key =key)
   if (!inherits(x, "list")) {
     stop("x must be of class list", call. = FALSE)
   }

--- a/R/package_show.R
+++ b/R/package_show.R
@@ -34,7 +34,7 @@ package_show <- function(id, use_default_schema = FALSE,
                          url = get_default_url(), key = get_default_key(),
                          as = 'list', ...) {
 
-  id <- as.ckan_package(id, url = url)
+  id <- as.ckan_package(id, url = url, key = key)
   args <- cc(list(id = id$id, use_default_schema = use_default_schema))
   res <- ckan_GET(url, 'package_show', args, key = key, ...)
   switch(as, json = res, list = as_ck(jsl(res), "ckan_package"),

--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -54,7 +54,7 @@ resource_create <- function(package_id = NULL, rcurl = NULL,
   webstore_last_updated = NULL, upload = NULL, url = get_default_url(),
   key = get_default_key(), as = 'list', ...) {
 
-  id <- as.ckan_package(package_id, url = url)
+  id <- as.ckan_package(package_id, url = url, key = key)
   body <- cc(list(package_id = id$id, url = rcurl, revision_id = revision_id,
                   description = description, format = format, hash = hash,
                   name = name, resource_type = resource_type, mimetype = mimetype,

--- a/R/resource_show.R
+++ b/R/resource_show.R
@@ -32,7 +32,7 @@
 resource_show <- function(id, url = get_default_url(), key = get_default_key(),
   as = 'list', ...) {
 
-  id <- as.ckan_resource(id, url = url)
+  id <- as.ckan_resource(id, url = url, key = key)
   res <- ckan_GET(url, 'resource_show', list(id = id$id), key = key, ...)
   switch(as, json = res, list = as_ck(jsl(res), "ckan_resource"),
     table = jsd(res))

--- a/man/package_create.Rd
+++ b/man/package_create.Rd
@@ -19,8 +19,8 @@ long and contain only lowercase alphanumeric characters, - and _, e.g. 'warandpe
 
 \item{title}{(character) the title of the dataset (optional, default: same as name)}
 
-\item{private}{(logical) whether or not the dataset should be private
-(optional, default: FALSE).}
+\item{private}{(logical) whether the dataset should be private (optional,
+default: FALSE), requires a value for \code{owner_org} if TRUE}
 
 \item{author}{(character) the name of the dataset's author (optional)}
 

--- a/man/package_create.Rd
+++ b/man/package_create.Rd
@@ -4,19 +4,23 @@
 \alias{package_create}
 \title{Create a package}
 \usage{
-package_create(name = NULL, title = NULL, author = NULL,
-  author_email = NULL, maintainer = NULL, maintainer_email = NULL,
-  license_id = NULL, notes = NULL, package_url = NULL,
-  version = NULL, state = "active", type = NULL, resources = NULL,
-  tags = NULL, extras = NULL, relationships_as_object = NULL,
-  relationships_as_subject = NULL, groups = NULL, owner_org = NULL,
-  url = get_default_url(), key = get_default_key(), as = "list", ...)
+package_create(name = NULL, title = NULL, private = FALSE,
+  author = NULL, author_email = NULL, maintainer = NULL,
+  maintainer_email = NULL, license_id = NULL, notes = NULL,
+  package_url = NULL, version = NULL, state = "active",
+  type = NULL, resources = NULL, tags = NULL, extras = NULL,
+  relationships_as_object = NULL, relationships_as_subject = NULL,
+  groups = NULL, owner_org = NULL, url = get_default_url(),
+  key = get_default_key(), as = "list", ...)
 }
 \arguments{
 \item{name}{(character) the name of the new dataset, must be between 2 and 100 characters
 long and contain only lowercase alphanumeric characters, - and _, e.g. 'warandpeace'}
 
 \item{title}{(character) the title of the dataset (optional, default: same as name)}
+
+\item{private}{(logical) whether or not the dataset should be private
+(optional, default: FALSE).}
 
 \item{author}{(character) the name of the dataset's author (optional)}
 


### PR DESCRIPTION
## The problem

On one of our internal CKAN instances, we have private datasets that do not behave properly upon attempts to `_show` or `_patch` them, even when the key is supplied. 

```r
library(ckanr)
key <- "XXXXX"
package_search("my_package", url="https://some_ckan_location.com", key=key)
## Error: 403 - Authorization Error
##   message Access denied: User  not authorized to read package BLAH-BLAH-BLAH
```

Some detective work suggests that the `as.ckan_package()` is trying to convert character strings into package objects but lacks the authorization to do so as the `key` is not passed.

## Solution

Pass the `key` to `as.ckan_package()`. I have only done this for the subset of functions that I actually needed for my day-to-day work, but it seems that it would be necessary for all functions.

Incidentally, I also took the liberty of adding a `private=` argument to `package_create()` so that I could easily create private packages. It works pretty well, but I'm not sure how you would like this to be tested; I don't want to spawn private repositories all over someone else's CKAN instance.