### PR TITLE
Add Support for Resources Extras 

### DIFF
--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -47,7 +47,7 @@
 #'    resource_create(description = "my resource",
 #'                    name = "bearsareus",
 #'                    upload = file,
-#'                    extras = list(my_extra = "some value")
+#'                    extras = list(my_extra = "some value"),
 #'                    rcurl = "http://google.com")
 #' }
 resource_create <- function(package_id = NULL, rcurl = NULL,

--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -21,10 +21,7 @@
 #' @param cache_last_updated (character) iso date string (optional)
 #' @param webstore_last_updated (character) iso date string (optional)
 #' @param upload (character) A path to a local file (optional)
-#' @param extras (list of resource extra dictionaries) - the resources's
-#' extras (optional), extras are arbitrary (key: value) metadata items
-#' that can be added to resources, each extra dictionary is a named
-#' list.
+#' @param extras (list) - the resources' extra metadata fields (optional)
 #' @template args
 #' @template key
 #'

--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -42,6 +42,7 @@
 #'                        description = "my resource",
 #'                        name = "bears",
 #'                        upload = file,
+#'                        extras = list(species = "grizzly"),
 #'                        rcurl = "http://google.com"
 #' ))
 #'
@@ -49,6 +50,7 @@
 #'    resource_create(description = "my resource",
 #'                    name = "bearsareus",
 #'                    upload = file,
+#'                    extras = list(my_extra = "some value")
 #'                    rcurl = "http://google.com")
 #' }
 resource_create <- function(package_id = NULL, rcurl = NULL,

--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -21,6 +21,10 @@
 #' @param cache_last_updated (character) iso date string (optional)
 #' @param webstore_last_updated (character) iso date string (optional)
 #' @param upload (character) A path to a local file (optional)
+#' @param extras (list of resource extra dictionaries) - the resources's
+#' extras (optional), extras are arbitrary (key: value) metadata items
+#' that can be added to resources, each extra dictionary is a named
+#' list.
 #' @template args
 #' @template key
 #'
@@ -52,8 +56,8 @@ resource_create <- function(package_id = NULL, rcurl = NULL,
   name = NULL, resource_type = NULL, mimetype = NULL,
   mimetype_inner = NULL, webstore_url = NULL, cache_url = NULL, size = NULL,
   created = NULL, last_modified = NULL, cache_last_updated = NULL,
-  webstore_last_updated = NULL, upload = NULL, url = get_default_url(),
-  key = get_default_key(), as = 'list', ...) {
+  webstore_last_updated = NULL, upload = NULL, extras = NULL,
+  url = get_default_url(), key = get_default_key(), as = 'list', ...) {
 
   id <- as.ckan_package(package_id, url = url, key = key)
   body <- cc(list(package_id = id$id, url = rcurl, revision_id = revision_id,
@@ -65,6 +69,7 @@ resource_create <- function(package_id = NULL, rcurl = NULL,
     cache_last_updated = cache_last_updated,
     webstore_last_updated = webstore_last_updated,
     upload = upfile(upload)))
+  body <- c(body, extras)
   res <- ckan_POST(url, 'resource_create', body = body, key = key, ...)
   switch(as, json = res, list = as_ck(jsl(res), "ckan_resource"),
     table = jsd(res))

--- a/R/resource_patch.R
+++ b/R/resource_patch.R
@@ -9,16 +9,26 @@
 #' # Setup
 #' ckanr_setup(url = "https://demo.ckan.org", key = getOption("ckan_demo_key"))
 #'
+#' # create a package
+#' (res <- package_create("twist", author="Alexandria"))
+#'
+#' # then create a resource
+#' file <- system.file("examples", "actinidiaceae.csv", package = "ckanr")
+#' (xx <- resource_create(package_id = res$id, description = "my resource"))
+#'
 #' # Get a resource
-#' res <- resource_show("b85948b6-f9ea-4392-805e-00511d6cf6c6")
+#' res <- resource_show(xx$id)
 #' res$description
 #'
 #' # Make some changes
-#' x <- list(description = "My newer description", "extra_key" = "my special value")
-#' resource_patch(x, id = res)
-#' # or pass id in directly
-#' # resource_patch(x, id = res$id)
-#' }
+#' x <- list(description = "My newer description")
+#' z <- resource_patch(x, id = res)
+#' z$description
+#'
+#' # Add an extra key:value pair
+#' extra <- list("extra_key" = "my special value")
+#' zz <- resource_patch(extra, id = res)
+#' zz$extra_key
 resource_patch <- function(x, id, url = get_default_url(),
   key = get_default_key(), as = 'list', ...) {
 

--- a/R/resource_patch.R
+++ b/R/resource_patch.R
@@ -14,14 +14,14 @@
 #' res$description
 #'
 #' # Make some changes
-#' x <- list(description = "My newer description")
+#' x <- list(description = "My newer description", "extra_key" = "my special value")
 #' resource_patch(x, id = res)
 #' # or pass id in directly
 #' # resource_patch(x, id = res$id)
 #' }
 resource_patch <- function(x, id, url = get_default_url(),
   key = get_default_key(), as = 'list', ...) {
-  
+
   id <- as.ckan_resource(id, url = url)
   if (!inherits(x, "list")) {
     stop("x must be of class list", call. = FALSE)

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -106,6 +106,7 @@ resource_update <- function(id, path, extras = list(),
   url = get_default_url(), key = get_default_key(),
   as = 'list', ...) {
 
+  assert(extras, "list")
   id <- as.ckan_resource(id, url = url)
   path <- path.expand(path)
   up <- upload_file(path)

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -102,7 +102,7 @@
 #' (xxx <- resource_update(xx, path=newpath))
 #' browseURL(xxx$url)
 #' }
-resource_update <- function(id, path, extras,
+resource_update <- function(id, path, extras = list(),
   url = get_default_url(), key = get_default_key(),
   as = 'list', ...) {
 

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -15,6 +15,7 @@
 #'
 #' @param id (character) Resource ID to update (required)
 #' @param path (character) Local path of the file to upload (required)
+#' @param extras (list) - the resources' extra metadata fields (optional)
 #' @template key
 #' @template args
 #' @return The HTTP response from CKAN, formatted as list (default), table,
@@ -48,6 +49,10 @@
 #'
 #' ## or from the resource id
 #' resource_update(xx$id, path=newpath)
+#'
+#' ## optionally include extra tags
+#' resource_update(xx$id, path=newpath,
+#'                 extras = list(some="metadata"))
 #'
 #' #######
 #' # Using default settings
@@ -97,8 +102,9 @@
 #' (xxx <- resource_update(xx, path=newpath))
 #' browseURL(xxx$url)
 #' }
-resource_update <- function(id, path, url = get_default_url(),
-  key = get_default_key(), as = 'list', ...) {
+resource_update <- function(id, path, extras,
+  url = get_default_url(), key = get_default_key(),
+  as = 'list', ...) {
 
   id <- as.ckan_resource(id, url = url)
   path <- path.expand(path)
@@ -108,6 +114,7 @@ resource_update <- function(id, path, url = get_default_url(),
     last_modified =
       format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
     url = "update")
+  body <- c(body, extras)
   res <- ckan_POST(url, 'resource_update', body = body, key = key, ...)
   switch(as, json = res, list = as_ck(jsl(res), "ckan_resource"),
          table = jsd(res))

--- a/tests/testthat/test-resource_update.R
+++ b/tests/testthat/test-resource_update.R
@@ -95,7 +95,7 @@ test_that("resource_update fails well", {
                "Authorization Error")
 })
 
-# key:value pairs
+# extras on resource_create
 test_that("resource_create gives back expected key:value pairs", {
   check_ckan(url)
   check_resource(url, rid)
@@ -105,6 +105,18 @@ test_that("resource_create gives back expected key:value pairs", {
                         name = "mapyay", upload = path,
                         extras = list(map_type = "mapbox"),
                         rcurl = "http://google.com", url = url, key = key)
+
+  # expected output
+  expect_equal(xx$map_type, "mapbox")
+})
+
+# extras on resource_update
+test_that("resource_update gives back expected key:value pairs", {
+  check_ckan(url)
+  check_resource(url, rid)
+
+  a <- resource_update(rid, path = path, extras = list(map_type = "mapbox"),
+                       url = url, key = key)
 
   # expected output
   expect_equal(xx$map_type, "mapbox")

--- a/tests/testthat/test-resource_update.R
+++ b/tests/testthat/test-resource_update.R
@@ -107,5 +107,5 @@ test_that("resource_create gives back expected key:value pairs", {
                         rcurl = "http://google.com", url = url, key = key)
 
   # expected output
-  expect_equal(a$map_type, "mapbox")
+  expect_equal(xx$map_type, "mapbox")
 })

--- a/tests/testthat/test-resource_update.R
+++ b/tests/testthat/test-resource_update.R
@@ -94,3 +94,18 @@ test_that("resource_update fails well", {
   expect_error(resource_update(rid, path=path, url=url, key="invalid-key"),
                "Authorization Error")
 })
+
+# key:value pairs
+test_that("resource_create gives back expected key:value pairs", {
+  check_ckan(url)
+  check_resource(url, rid)
+
+  path <- system.file("examples", "mapbox.html", package = "ckanr")
+  xx <- resource_create(package_id = did, description = "a map, yay",
+                        name = "mapyay", upload = path,
+                        extras = list(map_type = "mapbox"),
+                        rcurl = "http://google.com", url = url, key = key)
+
+  # expected output
+  expect_equal(a$map_type, "mapbox")
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This PR adds support for resource-level extras to the `resource_create` method.
* [X] add `extras` support to `resource_create`
* [X] test that `extras` are actually added when creating a package
* [X] add example usage for adding extras via `resource_create` and `resource_patch`

## Description
<!--- Describe your changes in detail -->
This adds the `extras` parameter to the `resource_create` method to allow adding arbitrary key:value pairs to ckan resources within a data package.

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

#149 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

The change allows the following

```R
foo <- resource_create(
    package_id = 'test-70mb', 
    name = 'foo-6', 
    extras = list(foo='bar', bar='baz'))
```

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
## Tests
* verify extras are added