### PR TITLE
Add http_method to resource_create, package_update and package_patch

### DIFF
--- a/R/package_patch.R
+++ b/R/package_patch.R
@@ -8,6 +8,8 @@
 #' (optional), extras are arbitrary (key: value) metadata items that can be
 #' added to datasets, each extra dictionary should have keys 'key' (a string),
 #' 'value' (a string)
+#' @param http_method (character) which HTTP method (verb) to use; one of 
+#' "GET" or "POST". Default: "GET"
 #' @template args
 #' @template key
 #' @examples \dontrun{
@@ -25,10 +27,10 @@
 #' package_patch(res, extras = list(list(key = "foo", value = "bar")))
 #' unclass(package_show(res))
 #' }
-package_patch <- function(x, id = NULL, extras = NULL, key = get_default_key(),
-  url = get_default_url(), as = 'list', ...) {
+package_patch <- function(x, id = NULL, extras = NULL, http_method = "GET", 
+  key = get_default_key(),url = get_default_url(), as = 'list', ...) {
 
-  x <- as.ckan_package(x, url = url, key = key)
+  x <- as.ckan_package(x, url = url, key = key, http_method = http_method)
   x <- unclass(x)
   if (!inherits(x, "list")) {
     stop("x must be of class list", call. = FALSE)

--- a/R/package_update.R
+++ b/R/package_update.R
@@ -3,6 +3,8 @@
 #' @export
 #' @param x (list) A list with key-value pairs
 #' @param id (character) Package identifier
+#' @param http_method (character) which HTTP method (verb) to use; one of 
+#' "GET" or "POST". Default: "GET"
 #' @template args
 #' @template key
 #' @examples \dontrun{
@@ -22,10 +24,10 @@
 #' # Then update the packge
 #' package_update(x, pkg$id)
 #' }
-package_update <- function(x, id, url = get_default_url(),
+package_update <- function(x, id, http_method = "GET", url = get_default_url(),
                            key = get_default_key(), as = 'list', ...) {
 
-  id <- as.ckan_package(id, url = url, key = key)
+  id <- as.ckan_package(id, url = url, key = key, http_method = http_method)
   if (class(x) != "list") {
     stop("x must be of class list", call. = FALSE)
   }

--- a/R/resource_create.R
+++ b/R/resource_create.R
@@ -22,6 +22,8 @@
 #' @param webstore_last_updated (character) iso date string (optional)
 #' @param upload (character) A path to a local file (optional)
 #' @param extras (list) - the resources' extra metadata fields (optional)
+#' @param http_method (character) which HTTP method (verb) to use; one of 
+#' "GET" or "POST". Default: "GET"
 #' @template args
 #' @template key
 #'
@@ -55,10 +57,10 @@ resource_create <- function(package_id = NULL, rcurl = NULL,
   name = NULL, resource_type = NULL, mimetype = NULL,
   mimetype_inner = NULL, webstore_url = NULL, cache_url = NULL, size = NULL,
   created = NULL, last_modified = NULL, cache_last_updated = NULL,
-  webstore_last_updated = NULL, upload = NULL, extras = NULL,
+  webstore_last_updated = NULL, upload = NULL, extras = NULL, http_method = "GET",
   url = get_default_url(), key = get_default_key(), as = 'list', ...) {
 
-  id <- as.ckan_package(package_id, url = url, key = key)
+  id <- as.ckan_package(package_id, url = url, key = key, http_method = http_method)
   body <- cc(list(package_id = id$id, url = rcurl, revision_id = revision_id,
     description = description, format = format, hash = hash,
     name = name, resource_type = resource_type, mimetype = mimetype,

--- a/man/package_patch.Rd
+++ b/man/package_patch.Rd
@@ -8,6 +8,7 @@ package_patch(
   x,
   id = NULL,
   extras = NULL,
+  http_method = "GET",
   key = get_default_key(),
   url = get_default_url(),
   as = "list",
@@ -24,6 +25,9 @@ x does not have an "id" field)}
 (optional), extras are arbitrary (key: value) metadata items that can be
 added to datasets, each extra dictionary should have keys 'key' (a string),
 'value' (a string)}
+
+\item{http_method}{(character) which HTTP method (verb) to use; one of
+"GET" or "POST". Default: "GET"}
 
 \item{key}{A privileged CKAN API key, Default: your key set with \code{\link{ckanr_setup}}}
 

--- a/man/package_update.Rd
+++ b/man/package_update.Rd
@@ -7,6 +7,7 @@
 package_update(
   x,
   id,
+  http_method = "GET",
   url = get_default_url(),
   key = get_default_key(),
   as = "list",
@@ -17,6 +18,9 @@ package_update(
 \item{x}{(list) A list with key-value pairs}
 
 \item{id}{(character) Package identifier}
+
+\item{http_method}{(character) which HTTP method (verb) to use; one of
+"GET" or "POST". Default: "GET"}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{ckanr_setup}} and \code{\link{get_default_url}}.}

--- a/man/resource_create.Rd
+++ b/man/resource_create.Rd
@@ -24,6 +24,7 @@ resource_create(
   webstore_last_updated = NULL,
   upload = NULL,
   extras = NULL,
+  http_method = "GET",
   url = get_default_url(),
   key = get_default_key(),
   as = "list",
@@ -69,6 +70,9 @@ added to. This should be an alphanumeric string. Required.}
 \item{upload}{(character) A path to a local file (optional)}
 
 \item{extras}{(list) - the resources' extra metadata fields (optional)}
+
+\item{http_method}{(character) which HTTP method (verb) to use; one of
+"GET" or "POST". Default: "GET"}
 
 \item{url}{Base url to use. Default: \url{http://data.techno-science.ca}. See
 also \code{\link{ckanr_setup}} and \code{\link{get_default_url}}.}


### PR DESCRIPTION
Added the `http_method` parameter to `resource_create`, `package_update` and `package_patch`. The default is `http_method = GET`. - #109 