### PR TITLE
Return unknown file format as NA to handle ZIP resource with subdirectory

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -86,6 +86,10 @@
 #' }
 ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
   key = get_default_key(), ...) {
+  
+  if (length(x) != 1) {
+    stop("`x` must be length 1.", call. = FALSE)
+  }
 
   store <- match.arg(store, c("session", "disk"))
   derived_file_fmt <- file_fmt(x)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -89,7 +89,7 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
 
   store <- match.arg(store, c("session", "disk"))
   derived_file_fmt <- file_fmt(x)
-  if (is.na(derived_file_fmt) & is.null(format)) {
+  if (is.na(derived_file_fmt) && is.null(format)) {
     stop("File format is not available from URL; please specify via `format` argument.")
   }
   fmt <- ifelse(is.na(derived_file_fmt), format, derived_file_fmt)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -89,10 +89,10 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
 
   store <- match.arg(store, c("session", "disk"))
   file_fmt <- file_fmt(x)
-  if (identical(file_fmt, character(0)) & is.null(format)) {
+  if (is.na(file_fmt) & is.null(format)) {
     stop("File format is not available from URL; please specify via `format` argument.")
   }
-  fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
+  fmt <- ifelse(is.na(file_fmt), format, file_fmt)
   fmt <- tolower(fmt)
   res <- fetch_GET(x, store, path, format = fmt, key = key, ...)
   if (store == "session") {

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -88,11 +88,11 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
   key = get_default_key(), ...) {
 
   store <- match.arg(store, c("session", "disk"))
-  file_fmt <- file_fmt(x)
-  if (is.na(file_fmt) & is.null(format)) {
+  derived_file_fmt <- file_fmt(x)
+  if (is.na(derived_file_fmt) & is.null(format)) {
     stop("File format is not available from URL; please specify via `format` argument.")
   }
-  fmt <- ifelse(is.na(file_fmt), format, file_fmt)
+  fmt <- ifelse(is.na(derived_file_fmt), format, derived_file_fmt)
   fmt <- tolower(fmt)
   res <- fetch_GET(x, store, path, format = fmt, key = key, ...)
   if (store == "session") {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -74,8 +74,8 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, key = NULL, ..
     }
   }
   # set file format
-  file_fmt <- file_fmt(x)
-  fmt <- ifelse(is.na(file_fmt), format, file_fmt)
+  derived_file_fmt <- file_fmt(x)
+  fmt <- ifelse(is.na(derived_file_fmt), format, derived_file_fmt)
   fmt <- tolower(fmt)
 
   # set API key header

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,7 +24,7 @@ ckan_VERB <- function(verb, url, method, body, key, query = list(),
   headers = list(), opts = list(), ...) {
 
   url <- notrail(url)
-  
+
   # check if proxy set
   proxy <- get("ckanr_proxy", ckanr_settings_env)
   if (!is.null(proxy)) {
@@ -75,14 +75,14 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, key = NULL, ..
   }
   # set file format
   file_fmt <- file_fmt(x)
-  fmt <- ifelse(identical(file_fmt, character(0)), format, file_fmt)
+  fmt <- ifelse(is.na(file_fmt), format, file_fmt)
   fmt <- tolower(fmt)
-  
+
   # set API key header
   if (!is.null(key)) {
     api_key_header <- list("X-CKAN-API-Key" = key)
   }
-  
+
   # initialize client, and set headers and proxy
   con <- crul::HttpClient$new(url = x, opts = list(...))
   if (!is.null(key)) con$headers <- list("X-CKAN-API-Key" = key)
@@ -127,7 +127,12 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, key = NULL, ..
 }
 
 file_fmt <- function(x) {
-  gsub("\\.", "", strextract(x, "\\.[A-Za-z0-9]+$"))
+  fmt <- gsub("\\.", "", strextract(x, "\\.[A-Za-z0-9]+$"))
+  if (length(fmt) == 0) {
+    NA
+  } else {
+    fmt
+  }
 }
 
 strextract <- function(str, pattern) regmatches(str, regexpr(pattern, str))


### PR DESCRIPTION
Trying to close an opendatatoronto issue that I'm very delinquent on...  https://github.com/sharlagelfand/opendatatoronto/issues/10

Turns out it can happen that a ZIP resource contains a *subdirectory* that contains the actual files - when this is the case, `ckan_fetch()` fails because the subdirectory's format cannot be parsed - `file_fmt()` returns `character(0)` instead of `NA` (if it returned `NA`, then `switch()` in `read_session()` would handle it more gracefully, instead of the error below):

``` r
library(ckanr)

ckan_fetch("https://ckan0.cf.opendata.inter.prod-toronto.ca/download_resource/81ea3260-057a-4e62-ae45-1f40191a8229", format = "zip")
# Error in switch(fmt, csv = { : EXPR must be a length 1 vector

traceback()
# 2: read_session(file_fmt(res$path[[i]]), res$data, res$path[[i]])
# 1: ckan_fetch("https://ckan0.cf.opendata.inter.prod-toronto.ca/download_resource/81ea3260-057a-4e62-ae45-1f40191a8229", 
#      format = "zip")
```

This is the contents of the resource's directory once unzipped (extracted by manually stepping through `ckan_fetch()`):

``` r
# [1] "/var/folders/j5/d1hztrys1xzg_8557yh176300000gn/T//RtmpXMMPkk/bikeshare2018/"                                        
# [2] "/var/folders/j5/d1hztrys1xzg_8557yh176300000gn/T//RtmpXMMPkk/bikeshare2018/Bike Share Toronto Ridership_Q1 2018.csv"
# [3] "/var/folders/j5/d1hztrys1xzg_8557yh176300000gn/T//RtmpXMMPkk/bikeshare2018/Bike Share Toronto Ridership_Q2 2018.csv"
# [4] "/var/folders/j5/d1hztrys1xzg_8557yh176300000gn/T//RtmpXMMPkk/bikeshare2018/Bike Share Toronto Ridership_Q3 2018.csv"
# [5] "/var/folders/j5/d1hztrys1xzg_8557yh176300000gn/T//RtmpXMMPkk/bikeshare2018/Bike Share Toronto Ridership_Q4 2018.csv"
```

The first element, `bikeshare2018/`, is where it fails, since it's just a directory.

This PR updates `file_fmt()` to return `NA` if the format cannot be parsed, instead of just `character(0)`. On this code in this branch, since the format of the directory is returned as `NA`, it has an element returned by `ckan_fetch()` that is just `NULL`:

``` r
library(ckanr)

bikeshare <- ckan_fetch("https://ckan0.cf.opendata.inter.prod-toronto.ca/download_resource/81ea3260-057a-4e62-ae45-1f40191a8229", format = "zip")

names(bikeshare)
# [1] "bikeshare2018"                            "Bike Share Toronto Ridership_Q1 2018.csv"
# [3] "Bike Share Toronto Ridership_Q2 2018.csv" "Bike Share Toronto Ridership_Q3 2018.csv"
# [5] "Bike Share Toronto Ridership_Q4 2018.csv"

bikeshare[["bikeshare2018"]]
# NULL
```



