### PR TITLE
Update ckan_fetch() to work with txt files

### DIFF
--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -83,6 +83,13 @@
 #' x <- ckan_fetch(res$url)
 #' names(x)
 #' head(x[["ChickenpoxAgegroups2017.csv"]])
+#' 
+#' # TXT file
+#' ckanr_setup("https://ckan0.cf.opendata.inter.prod-toronto.ca")
+#' res <- resource_show(id = "e4211f49-611f-438c-a444-aaa7f3f84117",
+#' as = "table")
+#' x <- ckan_fetch(res$url)
+#' head(x)
 #' }
 ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
   key = get_default_key(), ...) {

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -90,6 +90,13 @@
 #' as = "table")
 #' x <- ckan_fetch(res$url)
 #' head(x)
+#' 
+#' # TXT file, semicolon used as separator
+#' ckanr_setup("https://data.coat.no")
+#' res <- resource_show(id = "384fe537-e0bd-4e57-8a0d-420b7a745196",
+#' as = "table")
+#' x <- ckan_fetch(res$url, sep = ";")
+#' head(x)
 #' }
 ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
   key = get_default_key(), ...) {

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -101,7 +101,7 @@ ckan_fetch <- function(x, store = "session", path = "file", format = NULL,
   store <- match.arg(store, c("session", "disk"))
   derived_file_fmt <- file_fmt(x)
   if (is.na(derived_file_fmt) && is.null(format)) {
-    stop("File format is not available from URL; please specify via `format` argument.")
+    stop("File format is not available from URL; please specify via `format` argument.", call. = FALSE)
   }
   fmt <- ifelse(is.na(derived_file_fmt), format, derived_file_fmt)
   fmt <- tolower(fmt)

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -1,6 +1,21 @@
 #' Download a file
 #'
 #' @export
+#' 
+#' @details The `...` argument can be used to pass additional arguments to the 
+#' function that actually reads the file. It is only used when `store="session"`
+#'  and if the file is *not* a ZIP file. 
+#' 
+#' This list shows what function is used to read what file format, so that you can
+#' see what additional arguments are available:
+#' * csv: \link[utils]{read.csv}
+#' * xls, xlsx: \link[readxl]{read_excel}
+#' * xml: \link[xml2]{read_xml}
+#' * html: \link[xml2]{read_html}
+#' * json: \link[jsonlite]{fromJSON}
+#' * shp, geojson: \link[sf]{st_read}
+#' * txt: \link[utils]{read.table}
+#' 
 #'
 #' @param x URL for the file
 #' @param store One of session (default) or disk. session stores in R session,
@@ -9,7 +24,7 @@
 #' @param format Format of the file. Required if format is not detectable
 #' through file URL.
 #' @param key A CKAN API key (optional, character)
-#' @param ... Arguments passed on to the function used to read the file, if `store="disk"`. See details.
+#' @param ... Arguments passed on to the function used to read the file, if `store="session"`. See details.
 #' @examples \dontrun{
 #' # CSV file
 #' ckanr_setup("http://datamx.io")

--- a/R/ckan_fetch.R
+++ b/R/ckan_fetch.R
@@ -154,6 +154,15 @@ read_session <- function(fmt, dat, path) {
          geojson = {
            check4X("sf")
            sf::st_read(path)
+         },
+         txt = {
+           txt_res <- try(read.table(path), silent = TRUE)
+           
+           if (inherits(txt_res, "try-error")) {
+             stop("File cannot be read via `read.table()`. Please download and import into R manually.", call. = FALSE)
+           } else {
+             txt_res
+           }
          }
   )
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -89,7 +89,7 @@ fetch_GET <- function(x, store, path, args = NULL, format = NULL, key = NULL, ..
   if (!is.null(proxy)) con$proxies <- proxy
 
   if (store == "session") {
-    if (fmt %in% c("xls", "xlsx", "geojson")) {
+    if (fmt %in% c("xls", "xlsx", "geojson", "txt")) {
       dat <- NULL
       path <- tempfile(fileext = paste0(".", fmt))
       res <- con$get(query = args, disk = path)

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -105,5 +105,12 @@ as = "table")
 x <- ckan_fetch(res$url)
 names(x)
 head(x[["ChickenpoxAgegroups2017.csv"]])
+
+# TXT file
+ckanr_setup("https://ckan0.cf.opendata.inter.prod-toronto.ca")
+res <- resource_show(id = "e4211f49-611f-438c-a444-aaa7f3f84117",
+as = "table")
+x <- ckan_fetch(res$url)
+head(x)
 }
 }

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -26,7 +26,7 @@ through file URL.}
 
 \item{key}{A CKAN API key (optional, character)}
 
-\item{...}{Curl arguments passed on to \link[crul:verb-GET]{crul::verb-GET}}
+\item{...}{Arguments passed on to the function used to read the file, if \code{store="disk"}. See details.}
 }
 \description{
 Download a file

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -26,10 +26,27 @@ through file URL.}
 
 \item{key}{A CKAN API key (optional, character)}
 
-\item{...}{Arguments passed on to the function used to read the file, if \code{store="disk"}. See details.}
+\item{...}{Arguments passed on to the function used to read the file, if \code{store="session"}. See details.}
 }
 \description{
 Download a file
+}
+\details{
+The \code{...} argument can be used to pass additional arguments to the
+function that actually reads the file. It is only used when \code{store="session"}
+and if the file is \emph{not} a ZIP file.
+
+This list shows what function is used to read what file format, so that you can
+see what additional arguments are available:
+\itemize{
+\item csv: \link[utils]{read.csv}
+\item xls, xlsx: \link[readxl]{read_excel}
+\item xml: \link[xml2]{read_xml}
+\item html: \link[xml2]{read_html}
+\item json: \link[jsonlite]{fromJSON}
+\item shp, geojson: \link[sf]{st_read}
+\item txt: \link[utils]{read.table}
+}
 }
 \examples{
 \dontrun{

--- a/man/ckan_fetch.Rd
+++ b/man/ckan_fetch.Rd
@@ -112,5 +112,12 @@ res <- resource_show(id = "e4211f49-611f-438c-a444-aaa7f3f84117",
 as = "table")
 x <- ckan_fetch(res$url)
 head(x)
+
+# TXT file, semicolon used as separator
+ckanr_setup("https://data.coat.no")
+res <- resource_show(id = "384fe537-e0bd-4e57-8a0d-420b7a745196",
+as = "table")
+x <- ckan_fetch(res$url, sep = ";")
+head(x)
 }
 }


### PR DESCRIPTION
Updated `ckan_fetch()` to work with `txt` files (closes #160) - as we discussed in that issue, uses `read.table()` and errors if the txt file cannot be read via `read.table()`. Added an example into the docs too.

Just to look at when it works vs fails, using the examples from the linked issue:

``` r
library(ckanr)

head(ckan_fetch("https://ckan0.cf.opendata.inter.prod-toronto.ca/dataset/7b70189a-aede-42f1-b092-8708fa4f5fc3/resource/e4211f49-611f-438c-a444-aaa7f3f84117/download/pickup-schedule-2020.txt"))
#            V1           V2       V3      V4        V5        V6
# 1    Calendar WeekStarting GreenBin Garbage Recycling YardWaste
# 2 MondayNight     01/06/20        M       M         0         0
# 3 MondayNight     01/13/20        M       0         M         0
# 4 MondayNight     01/20/20        M       M         0         0
# 5 MondayNight     01/27/20        M       0         M         0
# 6 MondayNight     02/03/20        M       M         0         0
#              V7
# 1 ChristmasTree
# 2             M
# 3             0
# 4             M
# 5             0
# 6             0
```

``` r
library(ckanr)

ckan_fetch("https://ckan0.cf.opendata.inter.prod-toronto.ca/download_resource/c238eb23-474a-445f-8037-50d440502219", format = "txt")
# Error: File cannot be read via `read.table()`. Please download and import into R manually. 
```

I'm using the default `header = FALSE` in `read.table()` - I figure it's less of a pain to make one of the rows into the column names than it is to put the column names back into a row - lmk if you have strong feelings on this

I also took the opportunity to fix one error (that I wrote, of course!) which was missing `call. = FALSE`

Also, thank you for the access to push to the repo! 🎉 