### PR TITLE
Update servers.R add catalogue

### DIFF
--- a/R/servers.R
+++ b/R/servers.R
@@ -95,5 +95,7 @@ server_urls <- c(
   "https://data.ca.gov/",
   "https://data.chhs.ca.gov/",
   "http://data.whiterockcity.ca/",
-  "https://catalogue.data.gov.bc.ca"
+  "https://catalogue.data.gov.bc.ca",
+  "https://data.montreal.ca",
+  "https://www.donneesquebec.ca"
 )

--- a/R/servers.R
+++ b/R/servers.R
@@ -94,5 +94,6 @@ server_urls <- c(
   "https://data.cnra.ca.gov/",
   "https://data.ca.gov/",
   "https://data.chhs.ca.gov/",
-  "http://data.whiterockcity.ca/"
+  "http://data.whiterockcity.ca/",
+  "https://catalogue.data.gov.bc.ca"
 )


### PR DESCRIPTION
## Description
Add Government of British Columbia, Canada https://catalogue.data.gov.bc.ca back into list of servers(). 

## Related Issue
A version was removed as part of Issue #162 - http://catalogue.data.gov.bc.ca - however it works if https is used in URL.