### PR TITLE
Support updating of resource extra fields w/o including a path parameter

### DIFF
--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -120,18 +120,16 @@ resource_update <- function(id, path = NULL, extras = list(),
     path <- path.expand(path)
     up <- upfile(path)
     format <- pick_type(up$type)
-    body <- list(id = id$id, format = format, upload = up,
-      last_modified =
-        format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
-      url = "update")
+    body <- list(format = format, upload = up)
   } else {
-    body <- list(id = id$id,
-      last_modified =
-        format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
-      format = id$format,
-      url = "update")
+    body <- list()
   }
-  body <- c(body, extras)
+  default_body = list(id = id$id,
+    last_modified =
+      format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
+    url = "update"
+  )
+  body <- c(default_body, body, extras)
   res <- ckan_POST(url, 'resource_update', body = body, key = key,
     opts = list(...))
   switch(as, json = res, list = as_ck(jsl(res), "ckan_resource"),

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -14,7 +14,7 @@
 #' @export
 #'
 #' @param id (character) Resource ID to update (required)
-#' @param path (character) Local path of the file to upload (required)
+#' @param path (character) Local path of the file to upload (optional)
 #' @param extras (list) - the resources' extra metadata fields (optional)
 #' @template key
 #' @template args
@@ -102,19 +102,27 @@
 #' (xxx <- resource_update(xx, path=newpath))
 #' browseURL(xxx$url)
 #' }
-resource_update <- function(id, path, extras = list(),
+resource_update <- function(id, path = NULL, extras = list(),
   url = get_default_url(), key = get_default_key(),
   as = 'list', ...) {
 
   assert(extras, "list")
   id <- as.ckan_resource(id, url = url)
-  path <- path.expand(path)
-  up <- upfile(path)
-  format <- pick_type(up$type)
-  body <- list(id = id$id, format = format, upload = up,
-    last_modified =
-      format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
-    url = "update")
+  if (is.character(path)) {
+    path <- path.expand(path)
+    up <- upfile(path)
+    format <- pick_type(up$type)
+    body <- list(id = id$id, format = format, upload = up,
+      last_modified =
+        format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
+      url = "update")
+  } else {
+    body <- list(id = id$id,
+      last_modified =
+        format(Sys.time(), tz = "UTC", format = "%Y-%m-%d %H:%M:%OS6"),
+      format = id$format,
+      url = "update")
+  }
   body <- c(body, extras)
   res <- ckan_POST(url, 'resource_update', body = body, key = key,
     opts = list(...))

--- a/R/resource_update.R
+++ b/R/resource_update.R
@@ -1,9 +1,9 @@
-#' @title Update a resource's file attachment
+#' @title Update a resource
 #'
 #'
-#' @description This function will only update a resource's file attachment and
-#' the metadata key "last_updated". Other metadata, such as name or description,
-#' are not updated.
+#' @description This function can be used to update a resource's file attachment
+#' and "extra" metadata fields. Any update will also set the metadata key 
+#' "last_updated". Other metadata, such as name or description, are not updated.
 #'
 #' The new file must exist on a local path. R objects have to be written to a
 #' file, e.g. using `tempfile()` - see example.
@@ -53,6 +53,14 @@
 #' ## optionally include extra tags
 #' resource_update(xx$id, path=newpath,
 #'                 extras = list(some="metadata"))
+#'                 
+#' # Update a resource's extra tags
+#' ## add extra tags without uploading a new file
+#' resource_update(id,
+#'                 extras = list(some="metadata"))
+#'
+#' ## or remove all extra tags
+#' resource_update(id, extras = list())                 
 #'
 #' #######
 #' # Using default settings

--- a/man/resource_update.Rd
+++ b/man/resource_update.Rd
@@ -2,11 +2,11 @@
 % Please edit documentation in R/resource_update.R
 \name{resource_update}
 \alias{resource_update}
-\title{Update a resource's file attachment}
+\title{Update a resource}
 \usage{
 resource_update(
   id,
-  path,
+  path = NULL,
   extras = list(),
   url = get_default_url(),
   key = get_default_key(),
@@ -17,7 +17,7 @@ resource_update(
 \arguments{
 \item{id}{(character) Resource ID to update (required)}
 
-\item{path}{(character) Local path of the file to upload (required)}
+\item{path}{(character) Local path of the file to upload (optional)}
 
 \item{extras}{(list) - the resources' extra metadata fields (optional)}
 
@@ -39,9 +39,9 @@ The HTTP response from CKAN, formatted as list (default), table,
 or JSON.
 }
 \description{
-This function will only update a resource's file attachment and
-the metadata key "last_updated". Other metadata, such as name or description,
-are not updated.
+This function can be used to update a resource's file attachment
+and "extra" metadata fields. Any update will also set the metadata key
+"last_updated". Other metadata, such as name or description, are not updated.
 
 The new file must exist on a local path. R objects have to be written to a
 file, e.g. using \code{tempfile()} - see example.
@@ -81,6 +81,14 @@ resource_update(xx$id, path=newpath)
 ## optionally include extra tags
 resource_update(xx$id, path=newpath,
                 extras = list(some="metadata"))
+                
+# Update a resource's extra tags
+## add extra tags without uploading a new file
+resource_update(id,
+                extras = list(some="metadata"))
+
+## or remove all extra tags
+resource_update(id, extras = list())                 
 
 #######
 # Using default settings

--- a/tests/testthat/test-resource_update.R
+++ b/tests/testthat/test-resource_update.R
@@ -127,3 +127,30 @@ test_that("resource_update gives back expected key:value pairs", {
   # expected output
   expect_equal(a$map_type, "mapbox")
 })
+
+# extras on resource_update without path
+test_that("resource_update gives back expected key:value pairs even without path", {
+  check_ckan(url)
+  check_resource(url, rid)
+  
+  a <- resource_update(rid, extras = list(map_type = "mapbox"),
+                       url = url, key = key)
+  
+  # expected output
+  expect_equal(a$map_type, "mapbox")
+})
+
+# extras removed on resource_update with empty extras
+test_that("resource_update removes key:value pairs with empty extras", {
+  check_ckan(url)
+  check_resource(url, rid)
+  
+  a <- resource_update(rid, extras = list(map_type = "mapbox"),
+                       url = url, key = key)
+  
+  b <- resource_update(rid, extras = list(),
+                       url = url, key = key)
+  
+  # expected output
+  testthat::expect_null(b$map_type)
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR makes the `path` parameter to `resource_update` optional in order to support updating of resource extra fields.

While `resource_patch` ckan api allows for modifying the value of a given resource extra, it does not allow for deleting an extra that is no longer needed. (note that extras are not supported in the `ckanr::resource_patch`)

The current behavior only supports `resource_update` when a the file/url is being uploaded which may require an unnecessary download and reupload of a file just to remove a metadata field.

Todos
- [X] make `path` an optional parameter
- [x] add tests
- [x] update documentation 

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

```
# update an existing resource with an extra
id <- resource_update(id$id, extras = list(foo='bar'))

# purge all extras
resource_update(id)
```
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
