### PR TITLE
bug fixes package_create, package_update, package_patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 .RData
 .DS_Store
 notes.md
+*.Rproj
+.Rbuildignore
+.Rhistory
+.Rproj.user/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Client for the Comprehensive Knowledge Archive Network ('CKAN') API
 Description: Client for 'CKAN' API (<https://ckan.org/>). Includes interface
     to 'CKAN' 'APIs' for search, list, show for packages, organizations, and
     resources. In addition, provides an interface to the 'datastore' API.
-Version: 0.6.0.92
+Version: 0.6.0.93
 Authors@R: c(
     person("Scott", "Chamberlain",
     	role = c("aut", "cre"),

--- a/R/package_create.R
+++ b/R/package_create.R
@@ -64,7 +64,7 @@
 #'
 #' ## Example 2 - create package, add a resource
 #' (res <- package_create("helloworld", author="Jane DOe"))
-#' 
+#'
 #' # include a group
 #' # package_create("brownbear", groups = data.frame(id = "some-id"))
 #'
@@ -84,8 +84,11 @@ package_create <- function(name = NULL, title = NULL, private=FALSE,
     type = type, resources = resources, tags = tags,
     relationships_as_object = relationships_as_object,
     relationships_as_subject = relationships_as_subject, groups = groups,
-    owner_org = owner_org))
-  body <- c(body, extras)
+    owner_org = owner_org,extras = extras))
+
+#  if (length(extras) >0) {
+#    body <- list(body, extras = extras)
+#  }
   res <- ckan_POST(url, 'package_create',
                    body = tojun(body, TRUE), key = key,
                    encode = "json", headers = ctj(), opts = list(...))

--- a/R/package_patch.R
+++ b/R/package_patch.R
@@ -2,13 +2,13 @@
 #'
 #' @export
 #' @param x (list) A list with key-value pairs
-#' @param id (character) Resource ID to update (optional, required if 
+#' @param id (character) Resource ID to update (optional, required if
 #' x does not have an "id" field)
 #' @param extras (character vector) - the dataset's extras
 #' (optional), extras are arbitrary (key: value) metadata items that can be
 #' added to datasets, each extra dictionary should have keys 'key' (a string),
 #' 'value' (a string)
-#' @param http_method (character) which HTTP method (verb) to use; one of 
+#' @param http_method (character) which HTTP method (verb) to use; one of
 #' "GET" or "POST". Default: "GET"
 #' @template args
 #' @template key
@@ -21,13 +21,13 @@
 #'
 #' # Get a resource
 #' res <- package_show(res$id)
-#' res$title
+#' res$title <- "new title"
 #'
 #' # patch
 #' package_patch(res, extras = list(list(key = "foo", value = "bar")))
 #' unclass(package_show(res))
 #' }
-package_patch <- function(x, id = NULL, extras = NULL, http_method = "GET", 
+package_patch <- function(x, id = NULL, extras = NULL, http_method = "GET",
   key = get_default_key(),url = get_default_url(), as = 'list', ...) {
 
   x <- as.ckan_package(x, url = url, key = key, http_method = http_method)
@@ -42,8 +42,8 @@ package_patch <- function(x, id = NULL, extras = NULL, http_method = "GET",
     x$id <- id$id
   }
   if (!is.null(extras)) x$extras <- extras
-  res <- ckan_POST(url, method = 'package_patch', body = x, key = key,
-    encode = "json", opts = list(...))
+  res <- ckan_POST(url, method = 'package_patch', body = tojun(x), key = key,
+    encode = "json", headers = ctj(), opts = list(...))
   switch(as, json = res, list = as_ck(jsl(res), "ckan_package"),
          table = jsd(res))
 }

--- a/R/package_update.R
+++ b/R/package_update.R
@@ -3,7 +3,7 @@
 #' @export
 #' @param x (list) A list with key-value pairs
 #' @param id (character) Package identifier
-#' @param http_method (character) which HTTP method (verb) to use; one of 
+#' @param http_method (character) which HTTP method (verb) to use; one of
 #' "GET" or "POST". Default: "GET"
 #' @template args
 #' @template key
@@ -17,12 +17,14 @@
 #' # Next show the package to see the fields
 #' (res <- package_show(pkg$id))
 #'
-#' ## update just chosen things
 #' # Make some changes
-#' x <- list(maintainer_email = "heythere2@@things.com")
+#' res$maintainer_email <- "heythere2@@things.com"
+#'
+#' Note: package_upate will reset all attributes not mentioned in (x), including extras and resources.
+#' If you wish to retain resources, use package_patch() instead.
 #'
 #' # Then update the packge
-#' package_update(x, pkg$id)
+#' package_update(res, pkg$id)
 #' }
 package_update <- function(x, id, http_method = "GET", url = get_default_url(),
                            key = get_default_key(), as = 'list', ...) {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -243,3 +243,33 @@ handle_many <- function(x) {
     stop("query/q must be vector or list of strings", call.=FALSE)
   unlist(lapply(x, function(z) list(query = z)), FALSE)
 }
+
+err_handler <- function(x) {
+  if (x$status_code > 201) {
+    obj <- try({
+      err <- jsonlite::fromJSON(x$parse("UTF-8"))$error
+      tmp <- err[names(err) != "__type"]
+      errmsg <- paste(names(tmp), unlist(tmp[[1]]))
+      list(err = err, errmsg = errmsg)
+    }, silent = TRUE)
+    if (!inherits(obj, "try-error")) {
+      stop(sprintf("%s - %s\n  %s",
+                   x$status_code,
+                   obj$err$`__type`,
+                   obj$errmsg),
+                   #obj$err$message),
+           call. = FALSE)
+    } else {
+      obj <- {
+        err <- x$status_http()$message
+        errmsg <- x$parse("UTF-8")
+        list(err = err, errmsg = errmsg)
+      }
+      stop(sprintf("%s - %s\n  %s",
+                   x$status_code,
+                   obj$err,
+                   obj$errmsg),
+           call. = FALSE)
+    }
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -243,33 +243,3 @@ handle_many <- function(x) {
     stop("query/q must be vector or list of strings", call.=FALSE)
   unlist(lapply(x, function(z) list(query = z)), FALSE)
 }
-
-err_handler <- function(x) {
-  if (x$status_code > 201) {
-    obj <- try({
-      err <- jsonlite::fromJSON(x$parse("UTF-8"))$error
-      tmp <- err[names(err) != "__type"]
-      errmsg <- paste(names(tmp), unlist(tmp[[1]]))
-      list(err = err, errmsg = errmsg)
-    }, silent = TRUE)
-    if (!inherits(obj, "try-error")) {
-      stop(sprintf("%s - %s\n  %s",
-                   x$status_code,
-                   obj$err$`__type`,
-                   obj$errmsg),
-                   #obj$err$message),
-           call. = FALSE)
-    } else {
-      obj <- {
-        err <- x$status_http()$message
-        errmsg <- x$parse("UTF-8")
-        list(err = err, errmsg = errmsg)
-      }
-      stop(sprintf("%s - %s\n  %s",
-                   x$status_code,
-                   obj$err,
-                   obj$errmsg),
-           call. = FALSE)
-    }
-  }
-}


### PR DESCRIPTION
bug in fixes package_create, package_update, package_patch

## Description
package_create: extras were not converted correctly to son, fixed API call
correct format: (extras = list(key="xx", value=1)
package_update: documentation is not correct: fixed
package_patch: body was not converted to son: fixed API call

## Related Issue
I discovered these issues, while writing a script to update CKAN repository.
These are bugs to cause API calls to fail, cannot work without fixing.
