### PR TITLE
Add docker compose setup for local testing

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@ notes.md
 ^revdep$
 vignettes/
 inst/ignore/
+docker-compose.yml

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,11 +10,13 @@
 * Clone your version on your account down to your machine from your account, e.g,. `git clone https://github.com/<yourgithubusername>/ckanr.git`
 * Make sure to track progress upstream (i.e., on our version of `ckanr` at `ropensci/ckanr`) by doing `git remote add upstream https://github.com/ropensci/ckanr.git`. Before making changes make sure to pull changes in from upstream by doing either `git fetch upstream` then merge later or `git pull upstream` to fetch and merge in one step
 * Make your changes (bonus points for making changes on a new feature branch)
-* Test your changes locally. You can spin up a local CKAN site running at <http://localhost:5000/> for testing with
+* Test your changes locally. You need Docker Compose for this (installation instructions are available at <https://docs.docker.com/compose/install/>). You can spin up a local CKAN site with
 
     ```bash
     docker compose up
     ```
+
+    Enter http://localhost:5000/ in a browser to see CKAN running.
 
     There is a sysadmin user created by default with `username=ckan_admin` and `password=test1234`. You can retrieve the user details including the API KEY (for the R environment variable `TEST_API_KEY`) with
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,6 +10,17 @@
 * Clone your version on your account down to your machine from your account, e.g,. `git clone https://github.com/<yourgithubusername>/ckanr.git`
 * Make sure to track progress upstream (i.e., on our version of `ckanr` at `ropensci/ckanr`) by doing `git remote add upstream https://github.com/ropensci/ckanr.git`. Before making changes make sure to pull changes in from upstream by doing either `git fetch upstream` then merge later or `git pull upstream` to fetch and merge in one step
 * Make your changes (bonus points for making changes on a new feature branch)
+* Test your changes locally. You can spin up a local CKAN site running at <http://localhost:5000/> for testing with
+
+    ```bash
+    docker compose up
+    ```
+
+    There is a sysadmin user created by default with `username=ckan_admin` and `password=test1234`. You can retrieve the user details including the API KEY (for the R environment variable `TEST_API_KEY`) with
+
+    ```bash
+    docker exec ckanr-ckan-1 paster --plugin=ckan user ckan_admin
+    ```
 * Push up to your account
 * Submit a pull request to home base (likely master branch, but check to make sure) at `ropensci/ckanr`
 

--- a/ckanr.Rproj
+++ b/ckanr.Rproj
@@ -1,0 +1,17 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+services:
+  ckan:
+    image: "openknowledge/ckan-base:2.8"
+    environment:
+      - CKAN_SITE_URL=http://ckan:5000
+      - CKAN_SQLALCHEMY_URL=postgresql://ckan_default:pass@postgres/ckan_test
+      - CKAN_DATASTORE_WRITE_URL=postgresql://datastore_write:pass@postgres/datastore_test
+      - CKAN_DATASTORE_READ_URL=postgresql://datastore_read:pass@postgres/datastore_test
+      - CKAN_SOLR_URL=http://solr:8983/solr/ckan
+      - CKAN_REDIS_URL=redis://redis:6379/1
+      - CKAN_DATAPUSHER_URL=http://datapusher:8000
+      - CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
+      - TZ=UTC
+      - CKAN_SYSADMIN_NAME=ckan_admin
+      - CKAN_SYSADMIN_PASSWORD=test1234
+      - CKAN_SYSADMIN_EMAIL=mail@example.com
+    ports:
+      - "5000:5000"
+  postgres:
+    image: "ckan/ckan-postgres-dev:2.8"
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+  datapusher:
+    image: ghcr.io/keitaroinc/datapusher:0.0.17
+    environment:
+      - DATAPUSHER_MAX_CONTENT_LENGTH=10485760
+      - DATAPUSHER_CHUNK_SIZE=16384
+      - DATAPUSHER_CHUNK_INSERT_ROWS=250
+      - DATAPUSHER_DOWNLOAD_TIMEOUT=30
+      - DATAPUSHER_SSL_VERIFY=False
+  solr: 
+    image: "ckan/ckan-solr:2.8"
+  redis:
+    image: "redis:5.0.14"

--- a/tests/test-all.R
+++ b/tests/test-all.R
@@ -1,10 +1,4 @@
 library("testthat")
 library("ckanr")
 
-source("testthat/helper-ckanr.R")
-prepare_test_ckan()
-
-# Test CKAN fallback
-if(is.null(get_test_url())) ckanr_setup(test_url="https://demo.ckan.org")
-
 test_check("ckanr")

--- a/tests/testthat/helper-ckanr.R
+++ b/tests/testthat/helper-ckanr.R
@@ -1,24 +1,22 @@
-#' Given a TEST_API_KEY, create test resources on demo.ckan.org
+#' Given a TEST_API_KEY, create test resources on a CKAN site
 #'
 #' @keywords internal
 #' @details
 #' \code{prepare_test_ckan} creates an example dataset, resource, organisation,
-#' and group on \code{demo.ckan.org} for the test suite to use, and runs \code{ckanr_setup}
+#' and group on \code{localhost:5000} for the test suite to use, and runs \code{ckanr_setup}
 #' with the respective IDs.
 #'
-#' The only prerequisite for the tester is to register an account at
-#' \code{demo.ckan.org} and provide the API key as R environment variable
+#' The prerequisites for the tester is to run a CKAN site at
+#' \code{localhost:5000} and provide the API key as R environment variable
 #' \code{TEST_API_KEY}.
 #'
-#' This function aims to simplify using \code{demo.ckan.org} as test instance.
-#' \code{demo.ckan.org} periodically deletes all data, so test resources have to be
-#' re-created before running tests.
+#' This function aims to simplify using \code{localhost:5000} as test instance.
 #' @param test_url A test CKAN instance where we are allowed to create dummy resources
 #' @param test_key A working API key for an account on the test instance
-prepare_test_ckan <- function(test_url = "https://demo.ckan.org/",
+prepare_test_ckan <- function(test_url = "http://localhost:5000",
                               test_key = Sys.getenv("TEST_API_KEY")){
   if (test_key == "") {
-    message("Please provide your demo.ckan.org API key as parameter 'test_key' or via Sys.setenv(TEST_API_KEY = \"my-api-key\")")
+    message("Please provide your API key as parameter 'test_key' or via Sys.setenv(TEST_API_KEY = \"my-api-key\")")
     ckanr_setup(test_url=test_url)
   } else {
     message("Setting up test CKAN instance...")
@@ -44,6 +42,8 @@ prepare_test_ckan <- function(test_url = "https://demo.ckan.org/",
     try(package_create(name = "ckanr_test_dataset",
                        title = "ckanr test dataset",
                        owner_org = o$id,
+                       tags = list(list("name" = "ckanr"),
+                                   list("name" = "test")),
                        url = test_url,
                        key = test_key),
         silent = TRUE)
@@ -152,3 +152,5 @@ check_organization <- function(url, x){
                "Does an organization with slug", x, "exist on", url, "?"))
   }
 }
+
+prepare_test_ckan()

--- a/tests/testthat/test-ckan_fetch.R
+++ b/tests/testthat/test-ckan_fetch.R
@@ -2,6 +2,8 @@ context("ckan_fetch")
 
 skip_on_cran()
 
+rid <- get_test_rid()
+
 test_that("ckan_fetch returns error when file format can't be determined from URL", {
   expect_error(
     ckan_fetch("https://ckan0.cf.opendata.inter.sandbox-toronto.ca/datastore/dump/75c69a49-8573-4dda-b41a-d312a33b2e05"),
@@ -11,8 +13,7 @@ test_that("ckan_fetch returns error when file format can't be determined from UR
 
 test_that("ckan_fetch doesn't write any files to working directory when session = TRUE", {
   expect_identical(list.files(test_path()), {
-    ckanr_setup("http://datamx.io")
-    res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
+    res <- resource_show(id = rid, as = "table")
     df <- ckan_fetch(res$url)
     list.files(test_path())
   })
@@ -21,8 +22,7 @@ test_that("ckan_fetch doesn't write any files to working directory when session 
 test_that("ckan_fetch doesn't retain any files in temporary directory when session = TRUE", {
   dir <- tempdir()
   expect_identical(list.files(dir), {
-    ckanr_setup("http://datamx.io")
-    res <- resource_show(id = "e883510e-a082-435c-872a-c5b915857ae1", as = "table")
+    res <- resource_show(id = rid, as = "table")
     df <- ckan_fetch(res$url)
     list.files(dir)
   })

--- a/tests/testthat/test-resource_show.R
+++ b/tests/testthat/test-resource_show.R
@@ -6,7 +6,7 @@ u <- get_test_url()
 
 test_that("resource_show gives back expected class types", {
   check_ckan(u)
-  .a <- resource_search("name:data", url=u, limit=1)
+  .a <- resource_search("name:ckanr", url=u, limit=1)
   if (length(.a$results) > 0) {
     a <- resource_show(.a$results[[1]]$id, url=u)
     expect_is(a, "ckan_resource")
@@ -15,7 +15,7 @@ test_that("resource_show gives back expected class types", {
 
 test_that("resource_show works giving back json output", {
   check_ckan(u)
-  .b <- resource_search("name:data", url=u, limit=1)
+  .b <- resource_search("name:ckanr", url=u, limit=1)
   if (length(.b$results) > 0) {
     b <- resource_show(.b$results[[1]]$id, url=u, as="json")
     expect_is(b, "character")

--- a/tests/testthat/test-tag_search.R
+++ b/tests/testthat/test-tag_search.R
@@ -14,7 +14,7 @@ test_that("tag_search gives back expected class types", {
 
 test_that("tag_search works with many queries", {
   check_ckan(u)
-  a <- tag_search(query = c('a', 'al'), url = u)
+  a <- tag_search(query = c('c', 'ck'), url = u)
   expect_is(a, "list")
   expect_is(a[[1]], "ckan_tag")
   expect_named(a[[1]], c('vocabulary_id', 'id', 'name'))


### PR DESCRIPTION
## Description

- Add `docker-compose.yml` to spin-up a local CKAN site at `localhost:5000/ `
- Add basic instructions for how to launch the docker containers in the contribution guidelines
- Switch all testing using `demo.ckan.org/` and `datamx.io/` to `localhost:5000/` and make sure they pass
- Move `prepare_test_ckan()` from `tests/test-all.R` to `tests/testthat/helper-ckanr.R`

## Related Issue

See ropensci/ckanr#182 for the potential problems in testing against external CKAN sites.

