### PR TITLE
Update versions of github actions

### DIFF
--- a/.github/workflows/R-check.yaml
+++ b/.github/workflows/R-check.yaml
@@ -15,8 +15,7 @@ jobs:
         - { os: windows-latest, r: 'release'}
         - { os: windows-latest, r: 'devel'}
         - { os: macOS-latest, r: 'release'}
-        # - { os: macOS-latest, r: 'devel'}
-        - { os: ubuntu-16.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+        - { os: ubuntu-latest,  r: 'release'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -33,13 +32,14 @@ jobs:
       TEST_API_KEY: ${{secrets.TEST_API_KEY}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v2
 
       - name: Query dependencies
         run: |


### PR DESCRIPTION
If all environment variables and secrets are defined this should fix the current problems.

## Description

- Update to latest versions of actions `checkout`, `setup-r` and `setup-pandoc`
- Update `ubuntu-16.04` to `ubuntu-latest`
- Use input `use-public-rspm` from `setup-r` to serve binaries for Linux and Windows

