### PR TITLE
Fix resource_patch()

### DIFF
--- a/R/resource_patch.R
+++ b/R/resource_patch.R
@@ -38,8 +38,9 @@ resource_patch <- function(x, id, url = get_default_url(),
     stop("x must be of class list", call. = FALSE)
   }
   x$id <- id$id
+  if (!is.null(x$upload)) x$upload <- upfile(x$upload)
   res <- ckan_POST(url, method = 'resource_patch', body = x, key = key,
-    encode = "json", headers = ctj(), opts = list(...))
+    opts = list(...))
   switch(as, json = res, list = as_ck(jsl(res), "ckan_resource"),
     table = jsd(res))
 }


### PR DESCRIPTION
## Description

1. Fix POST request for resource_patch(). Old version caused `Error : 400 - Bad Request "Fehlerhafte Anfrage - JSON Fehler: Error decoding JSON data. Error: <BadRequest '400: Bad Request'> JSON data extracted from the request: {}"`.
2. Allow new file uploads through resource_patch(). Previously, the upload parameter of the request was ignored.

## Related Issue

None, I think.