### PR TITLE
Remove environment variables for testing ckanr on Github actions

### DIFF
--- a/.github/workflows/R-check.yaml
+++ b/.github/workflows/R-check.yaml
@@ -21,8 +21,6 @@ jobs:
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      CKANR_TEST_URL: ${{secrets.CKANR_TEST_URL}}
-      CKANR_TEST_BEHAVIOUR: ${{secrets.CKANR_TEST_BEHAVIOUR}}
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       R_KEEP_PKG_SOURCE: yes
       CKAN_VERSION: ${{ matrix.config.ckan-version }} # for docker compose up

--- a/tests/testthat/helper-ckanr.R
+++ b/tests/testthat/helper-ckanr.R
@@ -153,9 +153,7 @@ check_organization <- function(url, x){
   }
 }
 
-u <- get_test_url()
-
-if (ping(u)) {
+if (ping("http://localhost:5000")) {
   prepare_test_ckan()
 } else {
   message("CKAN is offline. Running tests that don't depend on CKAN.")


### PR DESCRIPTION
Closes #193

In https://github.com/ropensci/ckanr/pull/192 most of the environment variables were removed because they were 
being defined by prepare_test_ckan with the exception of CKANR_TEST_URL and CKANR_TEST_BEHAVIOUR.

We don't need to skip tests in Github Actions and if we hardcode CKANR_TEST_URL this makes it easier to run the 
test suite locally with docker compose because the only env var that needs to be defined is TEST_API_KEY as 
described in https://github.com/ropensci/ckanr/blob/master/.github/CONTRIBUTING.md.
